### PR TITLE
release: 全面更新文档，反映 CronJob、静默机制等最新功能

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,7 @@
 | 40028 | 系统插件不允许删除或停用 |
 | 40029 | 系统提示词不允许修改或删除 |
 | 40030 | 内置工具运行时常驻, 不支持启停 |
+| 40031 | CronJob 不存在 |
 | 50000 | 服务器内部错误 |
 
 **认证:** 除 `POST /login` 和 `GET /health` 外所有接口需 `Authorization: Bearer <token>` header，通过 `POST /login` 获取。
@@ -111,6 +112,8 @@
 17. [Webhook](#17-webhook)
 18. [日志](#18-日志)
 19. [健康检查](#19-健康检查)
+20. [CronJob 管理](#20-cronjob-管理)
+21. [前端 SPA 静态服务](#21-前端-spa-静态服务)
 
 ---
 
@@ -1146,9 +1149,10 @@ es.addEventListener('log', (e) => {
 6. `GET /prompts` + `POST /prompts` 配置 Prompt
 7. `GET /skills` + `POST /skills` 配置 Skill
 8. `GET /acl` + `POST /acl` 配置访问控制
-9. `PUT /t2i/config` + `PUT /sandbox/config` 配置 T2I/Sandbox
-10. `GET /chat-records/:chatAreaID` 查看历史聊天
-11. `GET /logs/stream` 实时查看日志
+9. `GET /cronjobs` + `POST /cronjobs` 配置定时任务
+10. `PUT /t2i/config` + `PUT /sandbox/config` 配置 T2I/Sandbox
+11. `GET /chat-records/:chatAreaID` 查看历史聊天
+12. `GET /logs/stream` 实时查看日志
 
 **注意事项:**
 
@@ -1161,10 +1165,109 @@ es.addEventListener('log', (e) => {
 - Prompt 禁止创建 `type=system` 类型（保留给系统锁定提示词 `__system_locked__`）；系统锁定提示词不允许修改/删除/停用
 - Tool ID 以 `builtin:` 前缀的为内置工具，运行时常驻，`PUT /tools/:id/toggle` 收到 `builtin:` 前缀返回 `40030 ToolIsBuiltin`
 - Adapter `listen_addr` 由 `listenAddr()` 规范化为 `host:port`；管理员列表持久化在 DB `admin_qq_numbers` 字段
+- CronJob 增删改/toggle 后自动 reload 调度器（基于 `robfig/cron`），无需手动重启；cron 表达式为 6 字段标准格式（秒 分 时 日 月 周）
 
 ---
 
-## 20. 前端 SPA 静态服务
+## 20. CronJob 管理
+
+定时任务管理，按 cron 表达式定时发送消息到指定私聊或群聊。CronJob 的调度依赖 `CronJobManager`（基于 `robfig/cron`），增删改后自动 reload 调度器。
+
+### CronJobResp 结构
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | UUID |
+| `name` | string | 任务名称 |
+| `cron_expr` | string | 标准 cron 表达式（6 字段：秒 分 时 日 月 周） |
+| `message` | string | 触发时发送的消息内容 |
+| `message_type` | string | 消息类型：`private`（私聊）/ `group`（群聊），默认 `private` |
+| `target_id` | int64 | 目标 QQ 号（私聊）或群号（群聊） |
+| `is_active` | bool | 是否启用 |
+| `last_run_at` | time | 上次执行时间（可为 null） |
+| `last_error` | string | 上次错误信息 |
+| `created_at` | time | 创建时间 |
+| `updated_at` | time | 更新时间 |
+
+### 20.1 GET /cronjobs
+
+**功能:** 列出所有定时任务。
+
+**响应** `data: CronJobResp[]`
+
+### 20.2 GET /cronjobs/:id
+
+**功能:** 获取单个定时任务详情。
+
+**路径参数:**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | CronJob UUID |
+
+**响应** `data: CronJobResp`
+
+### 20.3 POST /cronjobs
+
+**功能:** 新增定时任务，创建后自动同步调度器。
+
+**请求体** `AddCronJobReq`:
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 任务名称 |
+| `cron_expr` | string | 是 | cron 表达式（6 字段：秒 分 时 日 月 周），如 `0 0 9 * * *` 表示每天 9:00 |
+| `message` | string | 是 | 触发时发送的消息 |
+| `message_type` | string | 否 | 消息类型，默认 `private` |
+| `target_id` | int64 | 是 | 目标 QQ 号或群号 |
+| `is_active` | bool | 是 | 是否立即启用 |
+
+**响应** `data: CronJobResp`
+
+**示例:**
+
+```bash
+curl -X POST http://localhost:8090/api/v1/cronjobs \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"早安提醒","cron_expr":"0 0 9 * * *","message":"早上好！","message_type":"private","target_id":123456,"is_active":true}'
+```
+
+### 20.4 PUT /cronjobs/:id
+
+**功能:** 更新定时任务（覆盖更新），更新后自动同步调度器。
+
+**路径参数:** `id` (CronJob UUID)
+
+**请求体** `UpdateCronJobReq`（字段同 `AddCronJobReq`）
+
+**响应** `data: CronJobResp`
+
+### 20.5 DELETE /cronjobs/:id
+
+**功能:** 删除定时任务，删除后自动同步调度器。
+
+**路径参数:** `id` (CronJob UUID)
+
+**响应** `data: null`
+
+### 20.6 PUT /cronjobs/:id/toggle
+
+**功能:** 启用/停用定时任务，同步调度器。
+
+**路径参数:** `id` (CronJob UUID)
+
+**请求体** `ToggleCronJobReq`:
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `is_active` | bool | 是 | 目标状态 |
+
+**响应** `data: null`
+
+---
+
+## 21. 前端 SPA 静态服务
 
 后端通过 Hertz `NoRoute` 兜底, 同端口 (`:8090`) 服务 Vue 前端 SPA, 路径与 API 互不冲突:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,7 @@ JuanNiang-Neo 是一个基于 OneBot11 协议的 QQ 聊天 Agent 系统，类 As
 │          │          │ session  │ handler  │                │
 │          │          │ skill    │          │                │
 │          │          │ tool     │          │                │
+│          │          │ cronjob  │          │                │
 ├──────────┴──────────┴──────────┴──────────┴────────────────┤
 │                     adapter/ (OneBot11 WS)                  │
 │                 事件接收 · API调用 · 消息构造                 │
@@ -33,7 +34,7 @@ JuanNiang-Neo 是一个基于 OneBot11 协议的 QQ 聊天 Agent 系统，类 As
 |------|--------|------|
 | **入口** | `cmd/server/main.go` | 组装所有模块, 启动服务, 优雅退出 |
 | **适配器** | `internal/adapter/` | OneBot11 反向 WS 服务端: 事件解析、API 封装、消息段构造 |
-| **Agent** | `internal/agent/` | Agent 核心: MCP、记忆、提示词、Provider、会话、技能、工具 |
+| **Agent** | `internal/agent/` | Agent 核心: MCP、记忆、提示词、Provider、会话、技能、工具、定时任务 |
 | **核心库** | `internal/core/` | 数据模型 (GORM)、DAO、缓存 (Redis)、ACL |
 | **Web API** | `internal/api/` | Hertz Web 管理面板: JWT 鉴权、CRUD API |
 | **插件** | `internal/pluggin/` | gopher-lua 引擎: 插件生命周期、API 暴露、事件拦截 |
@@ -58,6 +59,7 @@ ChatArea  ─── 聊天区域 (private/group, Session+Memory 的集合)
   └─ BackgroundTask  ── 后台任务: DAG 步骤 + 结果缓冲区
 ChatRecord ─── 聊天记录 (user/assistant/tool)
 Plugin     ─── Lua 插件元数据 (Manifest.System=true 表示系统插件不可删/不可停用)
+CronJob    ─── 定时任务 (cron 表达式 + 消息内容 + 目标ID + 启用状态 + 最后执行时间)，通过 channel 注入 Agent 事件循环
 ACLRule    ─── ACL 规则 (用户×ChatArea×权限)
 ```
 
@@ -79,6 +81,8 @@ ChatArea (1) ──< ACLRule (1:N per user)
 
 LongTermMemory (1) ──< LongTermMemoryItem (1:N)
 ```
+
+CronJob 独立于 ChatArea，不与其他模型建立外键关系。触发时由 `internal/agent/cronjob.Manager` 构造合成 `adapter.Event`（`PostType: "cronjob"`, `IsCronJob: true`），通过 `CronJobEvents` channel 注入主事件循环，走 `handleMessage` 标准处理路径（跳过插件拦截）。调度器使用 `robfig/cron`，支持秒级 cron 表达式；API 层变更时自动调用 `Manager.Reload()` 同步。
 
 ### 插件 API 分组
 
@@ -136,3 +140,41 @@ LongTermMemory (1) ──< LongTermMemoryItem (1:N)
 - **开发模式**: 前端走 Vite `:3000` 热更新, `vite.config.ts` 代理 `/api` → `:8090`, 因此开发期 Go 的 SPA fallback 不会被触发。
 - **生产模式 (容器)**: `deployments/Dockerfile` 多阶段构建把 `web/dist` 拷到 `/app/web/dist`, `ENV WEB_DIR=/app/web/dist`, 单容器同端口暴露 Web 面板 + API + 前端。
 - 路径穿越防护: `SPAHandler` 通过 `filepath.Rel` 校验目标文件必须落在 `webDir` 之内。
+
+---
+
+## 群聊回复策略与静默机制
+
+群聊场景下 Agent 不应对每条消息都回复，否则会造成刷屏。系统通过**提示词规则 + 代码层兜底过滤**两层机制实现智能静默。
+
+### 提示词中的群聊回复规则
+
+群聊回复判断由 `internal/agent/prompt/prompt.go` 注入的系统提示词驱动，核心规则如下：
+
+- **被@铁律**：消息中 @了机器人、直接提到名字/昵称/称呼、或是对上一条回复的延续追问时，**无条件立即回复**。此规则覆盖一切静默规则，是唯一不可违背的绝对命令。
+- **条件 B — 内容直接相关**：询问能力/功能/使用方法，或请求执行操作（搜索、生图、群管理等），即使未 @也可以回复。
+- **条件 C — 对话上下文指向你**：短期记忆显示刚参与了这段对话，且新消息是自然延续。
+- **条件 D — 热聊参与**：短期记忆显示最近 5-10 条消息中有 ≥3 人连续讨论同一话题时视为热聊状态，可适当参与（每 5-10 条最多回 1 条）。话题切换时自动退出，不第一个打破沉默，不插话二人对话。
+- **明确不回复**：日常闲聊、互怼、问候、互 @（非 @自己）、无关话题、纯表情/图片、单字消息等。
+
+### 静默标记 `__NO_REPLY__`
+
+LLM 被要求在判定不回复时**仅输出固定标记 `__NO_REPLY__`**，不输出任何其他文字、不调用任何工具。系统检测到此标记后自动丢弃回复，不向 QQ 发送任何内容。
+
+### 代码层 `isSilenceResponse` 兜底过滤
+
+定义在 `internal/agent/event.go`，对**所有群聊消息**的 LLM 文本输出做二次校验：
+
+```go
+const SilenceToken = "__NO_REPLY__"
+```
+
+`isSilenceResponse(content)` 的逻辑：
+
+1. **主路径**：检测内容是否包含 `__NO_REPLY__` 标记 — 命中则静默。
+2. **兜底匹配**：对长度 ≤15 字符的短消息，匹配已知静默短语列表（如"保持静默"、"不回复"、"不插话"、"不响"、"做空气"、"装死"等），以及静默类表情（😶/🤐/🙈/🫥）。命中任意一个即为静默。
+3. **子串兜底**：对短消息额外检查是否包含"静默"、"不回复"、"不插话"、"不响"、"做空气"、"装死"等关键词。
+
+当 `isSilenceResponse` 返回 `true` 时，`handleMessage` 跳过 `sendReply`、`recordChat` 和 `handleToolCalls`，实现三层拦截：不发送、不记录、不执行工具调用。静默响应日志仅打一条 `slog.Info`。
+
+> **设计意图**：提示词规则是主防线，LLM 在绝大多数情况下正确输出 `__NO_REPLY__`。代码层兜底用于防止 LLM 不遵守标记约定（如输出"保持静默"等自然语言废话），确保群聊不被打扰。

--- a/docs/call-stack.md
+++ b/docs/call-stack.md
@@ -33,11 +33,13 @@ main()
 │       ├─ loadMCPs(ctx)                   // DB → MCPGroup (MCP SDK)
 │       ├─ loadSkills(ctx)                 // DB → SkillEngine
 │       ├─ NewBackgroundTaskExecutor(...)
-│       └─ NewDrainerAgent(...)
+│       ├─ NewDrainerAgent(...)
+│       └─ cronjob.New(h.DAO.CronJob, h.CronJobEvents)  // CronJob 调度器初始化
 │
 ├─ hago.Start(ctx)
 │   ├─ go BgTaskExecutor.Run()
 │   ├─ go DrainerAgent.Run()
+│   ├─ go h.CronJobManager.Run(ctx)
 │   └─ go runEventLoop()
 │
 ├─ pluggin.NewPluginEngine(path, adapter, db, cache, t2i, sandbox, dao, agentOp)
@@ -72,7 +74,7 @@ OneBot11 WS → adapter.readLoop()
 ├─ gjson 解析 → parseEvent()
 ├─ events chan ← Event{PostType, Message, Notice, ...}
 │
-└─ agent.runEventLoop() ← for ev := range adapter.Events()
+└─ agent.runEventLoop()  // for + select 多路复用
     │
     ├─ pluggin.OnMessage(event)
     │   ├─ 存储 currentEv (供 agent.get_current_chat_area() 查询)
@@ -108,13 +110,17 @@ OneBot11 WS → adapter.readLoop()
         │   └─ parseChatResponse → ChatResponse{Message, TokenUsage}
         │
         ├─ [文本响应]:
-        │   ├─ sendReply(msg, content)
-        │   │   ├─ [private] adapter.SendPrivateMsg
-        │   │   └─ [group]   adapter.SendGroupMsg
-        │   │       └─ wsServer.callAPI("send_group_msg", params)
-        │   │           └─ WS write → OneBot11 客户端 → QQ API
-        │   ├─ dao.ChatRecord.Create(assistant)
-        │   └─ memory.AddShortTermMessage(assistant)
+        │   ├─ [群聊] isSilenceResponse(content)?
+        │   │   ├─ 是 → 丢弃(不记录), 跳过 handleToolCalls
+        │   │   └─ 否 → sendReply(msg, content)
+        │   │       ├─ [private] adapter.SendPrivateMsg
+        │   │       └─ [group]   adapter.SendGroupMsg
+        │   │           └─ wsServer.callAPI("send_group_msg", params)
+        │   │               └─ WS write → OneBot11 客户端 → QQ API
+        │   │       ├─ dao.ChatRecord.Create(assistant)
+        │   │       └─ memory.AddShortTermMessage(assistant)
+        │   │
+        │   └─ [私聊] → sendReply → 记录 (同上)
         │
         └─ [Tool Call 响应]:
             └─ handleToolCalls(ctx, msg, chatAreaID, ...)
@@ -142,6 +148,10 @@ OneBot11 WS → adapter.readLoop()
                         │   ├─ [步骤完成]: sendProgress (每 3 步)
                         │   └─ [任务完成]: LLM 整合 → sendReply
                         └─ loop
+    │
+    └─ [CronJob 事件]:
+        └─ case ev, ok := <-h.CronJobEvents:  // 注入队列后的 CronJob 事件
+            └─ processEvent(ctx, ev) → handleMessage (跳过 Plugin 拦截)
 ```
 
 ## MCP 工具调用栈

--- a/docs/event-flow.md
+++ b/docs/event-flow.md
@@ -64,6 +64,33 @@
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## 完整事件流 (CronJob → 定时任务)
+
+```
+┌──────────────────────┐
+│  CronJobManager      │  来自 pluggin.yaml
+│  cron 定时表达式      │  (如 "0 */1 * * *")
+└──────────┬───────────┘
+           │ Run() → 遍历已注册 cron job
+           │ 到期触发 → 构造 Event
+           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  构造事件                                                    │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  PostType = "cronjob"                                 │  │
+│  │  IsCronJob = true                                     │  │
+│  │  RawMessage = 插件注册时指定的文本                      │  │
+│  │  UserID = "system" / GroupID = ""                     │  │
+│  └──────────────────────────────────────────────────────┘  │
+│                           │                                 │
+│              CronJobEvents chan (buffer 32)                 │
+└───────────────────────────┼─────────────────────────────────┘
+                            │
+                            ▼
+              runEventLoop 统一监听处理
+              (与 OneBot11 事件共用同一事件循环)
+```
+
 ## Agent 处理流程 (handleMessage)
 
 ```
@@ -92,7 +119,11 @@ handleMessage(ctx, event)
 │
 ├─ 6. LLM 调用 (Provider.Chat)
 │     │
-│     ├─ 文本响应 → sendReply → 记录 ChatRecord
+│     ├─ 文本响应 → isSilenceResponse 检查
+│     │     ├─ 匹配 __NO_REPLY__ 或静默短语 → 丢弃响应
+│     │     │     ├─ 不发送, 不记录 ChatRecord
+│     │     │     └─ 同时跳过 Tool Calls
+│     │     └─ 不匹配 → sendReply → 记录 ChatRecord
 │     │
 │     └─ Tool Call 响应 → handleToolCalls
 │           │
@@ -139,9 +170,14 @@ Start()
 │
 ├─ go BgTaskExecutor.Run(ctx)
 ├─ go DrainerAgent.Run(ctx)
-└─ go runEventLoop(ctx)    ← 阻塞主循环
+├─ go CronJobManager.Run(ctx)
+├─ CronJobEvents chan (buffer 32)    ← cron 事件源
+└─ go runEventLoop(ctx)               ← 阻塞主循环
       │
-      └─ for ev := range adapter.Events()
+      ├─ case ev := <-adapter.Events()       ← OneBot11 事件
+      ├─ case ev := <-CronJobEvents          ← CronJob 事件
+      │
+      └─ 统一处理
            │
            ├─ Plugin 拦截 (可消费事件)
            └─ Agent 处理

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -104,6 +104,13 @@
   4. `dao.Prompt.ListByType(Custom)` — 用户自定义补充
 - **API 守卫**: `UpdatePrompt` / `DeletePrompt` / `TogglePrompt` 在 Service 层检查 `existing.IsSystem`，命中则返回 `40029 PromptIsSystem`；`AddPrompt` / `UpdatePrompt` 拒绝用户将 `Type` 设为 `system`
 - `BuildFullContext`: SystemPrompt + 长期记忆 + 工具描述，内部调用 `BuildSystemPrompt`
+- **群聊回复策略**（在 `SystemLockedPromptContent` 中定义）:
+  - **被@铁律**: 当消息中包含@本机器人时，无条件回复，覆盖所有静默规则
+  - **相关性判断**: 不满足被@铁律时，综合以下条件决定是否回复：
+    - **条件 B** — 消息内容与机器人知识/能力相关（可直接回答或提供价值）
+    - **条件 C** — 当前对话上下文中机器人刚参与过相关话题（延续讨论）
+    - **条件 D** — 群聊处于热聊状态且内容适合自然参与（融入对话）
+  - **静默标记 `__NO_REPLY__`**: 当 LLM 判断无需回复时，系统提示词要求其输出 `__NO_REPLY__` 标记；系统层检测到该标记后丢弃响应（不发消息、不记聊天记录、不存短期记忆）；仅限群聊场景，私聊始终回复
 
 **Session (`session/`)**
 - MessageHistory 存 Redis List (LPush/LRange)
@@ -132,6 +139,21 @@
 - 匹配策略: 关键词 (strings.Contains) + 正则 (regexp.Compile)
 - 优先级排序: Priority 降序
 - 系统技能 (`IsSystem=true`): 每次对话强制加载
+
+**CronJob 定时任务 (`agent/cronjob/`)**
+- `Manager` 结构: 封装 `robfig/cron/v3` 调度器，管理定时任务生命周期
+- `Run(ctx)`: 启动 cron 调度器，监听 `ctx.Done()` 实现优雅退出
+- `Reload(ctx)`: 从 DB 重新加载所有启用的任务 (`IsActive=true`)，清空并重建 cron 条目
+- `makeJobFunc(task)`: 构造 `MessageEvent`（触发者为空）→ 封装为 `Event{PostType:"cronjob", IsCronJob:true}` → 非阻塞写入 `CronJobEvents` channel
+- **事件处理**: `processEvent` 中对 `IsCronJob=true` 的事件跳过 Plugin 拦截和 ACL 检查，直接进入 Agent 处理链
+
+**群聊静默过滤器**
+- `SilenceToken = "__NO_REPLY__"` 常量（`internal/agent/event.go`）
+- `isSilenceResponse(content)`: 双路径检测
+  - 主路径: `strings.Contains(content, SilenceToken)` 精确匹配静默标记
+  - 兜底路径: 匹配静默短语/emoji 列表（LLM 未按要求输出标记时的容错）
+- `handleMessage` 中: 群聊场景 + 静默响应 → 丢弃该响应（不发 QQ 消息、不记录 `ChatRecord`、不写入短期记忆），同时跳过 ToolCalls 结果处理
+- 兜底短语列表: `保持静默` / `不回复` / `不响应` / `做空气` / `装死` / `😶` / `🤐` 等
 
 ### 4. 后台任务系统
 


### PR DESCRIPTION
### CronJob 定时任务 (a2e5fd2, 1f29f15, 97259fa)
基于 robfig/cron/v3 实现定时消息触发，通过 channel 注入 Agent 事件循环：

- 模型 CronJob : cron 表达式、消息内容/类型、目标 ID、启用状态、执行记录
- 调度器 cronjob.Manager : 启动/停止/热加载，任务触发时构造合成 Event（ PostType="cronjob" ）非阻塞写入 CronJobEvents channel
- API : 6 个端点（ /api/v1/cronjobs CRUD + Toggle），增删改自动调用 Reload() 同步调度器
- 前端 : CronJobsPage.vue — 数据表格 + 新增/编辑弹窗 + 启用开关
- 安全 : CronJob 事件跳过 Plugin 拦截和 ACL 检查
### 群聊静默机制 (6f2ba11, 70f0520, e8cedc8)
解决 Agent 在群聊中对无关消息乱回复的问题：

- Prompt 层 :
  - 被@铁律 — 无条件回复，覆盖所有静默规则
  - 相关性判断 — 条件 B/C/D（内容相关/上下文延续/热聊参与）
  - 静默标记 __NO_REPLY__ — LLM 不回复时输出此标记，系统检测后丢弃
- 代码层兜底 isSilenceResponse :
  - 主路径 — 匹配 SilenceToken = "__NO_REPLY__"
  - 兜底 — 15 字符内匹配静默短语（保持静默/不响/做空气/装死/😶 等）
  - 拦截效果 — 不发消息、不记聊天记录、跳过 Tool Calls
### 文档更新 (55b1ff6)
5 份核心文档同步更新： api.md (+111)、 architecture.md (+44)、 event-flow.md (+42)、 call-stack.md (+28)、 implementation.md (+22)