### PR TITLE
ci: 添加 GitHub Actions 自动构建并推送 Docker 镜像到 GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,69 @@
+name: Docker Build & Push to GHCR
+
+on:
+  # 手动触发
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: '镜像标签 (默认 latest)'
+        required: false
+        default: 'latest'
+        type: string
+
+  # main 分支 PR 合并时自动触发
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # TuF3i/JuanNiang-Neo -> ghcr.io/tuf3i/juanniang-neo
+
+jobs:
+  build-and-push:
+    # PR 合并触发时仅在 merged 为 true 时运行; 手动触发时始终运行
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ inputs.tag || 'latest' }}
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployments/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
新增 CI workflow，在 main 分支 PR 合并时自动构建多平台 Docker 镜像并推送到 ghcr.io 。

> 镜像地址: ghcr.io/tuf3i/juanniang-neo