### PR TITLE
AgentLite 模式 + Markdown 去除 + 多项修复

### DIFF
--- a/changelog/2026-07-23-agent-lite-and-fixes.md
+++ b/changelog/2026-07-23-agent-lite-and-fixes.md
@@ -1,0 +1,53 @@
+# Changelog 2026-07-23
+
+## 新功能
+
+### AgentLite 模式
+- 精简模式：不向 LLM 暴露工具/MCP，跳过 Agent 循环，LLM 直接回复
+- 记忆、提示词、Skill 行为不受影响，回复仍写回记忆
+- 注入 system 提示词告知 LLM 当前处于精简模式
+- 此模式下关闭分条回复功能，整条消息发送
+- 开关位于 Web 面板「回复设置 → 其他设置」
+
+### Markdown 去除工具
+- Agent 发送消息前去除 `**加粗**`、`*斜体*`、`` `代码` ``、`[链接](url)`、`# 标题`、`> 引用`、列表、表格等格式
+- 修复了 `|` 替换破坏 `<|msg|>` 分隔符导致分条回复失效的问题（改为先拆分再去格式）
+- 开关位于 Web 面板「回复设置 → 其他设置」
+
+### 回复设置页面重构
+- 原「核心配置 - 回复策略」改名为「回复设置」
+- 页面改为左右双列卡片布局：回复策略（7）+ 其他设置（5）
+- 其他设置卡片含 AgentLite 开关和 Markdown 去除开关
+
+### 机器人名字配置
+- 相关性检查时参考机器人名字辅助判断
+- 配置位于「回复设置 → 回复策略 → 相关性阈值」卡片内
+
+### 仅应用部署
+- 新增 `deployments/docker-compose.app-only.yaml`，连接外部 Postgres + Redis
+- 支持 `PLUGGINS_DIR` 环境变量自定义宿主侧插件目录
+
+### Dockerfile.cn 国内镜像
+- Alpine 源替换为 aliyun 镜像加速
+
+## Bug 修复
+
+### DAO 零值字段不更新
+- **问题**：Web 界面关闭沙箱后 DB 未同步，重启后状态丢失
+- **原因**：GORM `Updates(struct)` 跳过零值字段，`IsActive: false`（bool 零值）无法写入
+- **修复**：所有 `Updates` 调用加 `Select("*")` 强制更新全部字段
+- **影响范围**：sandboxDao、onebotDao、webhookDao、t2iDao
+
+### 插件命令被路由给 Agent
+- **问题**：相关性回复模式和仅 Plugin 模式下，插件命令仍被交给 Agent 执行
+- **原因**：Lua 插件 handler 未返回 `consumed` 时默认 `false`，`OnMessage` 因 `c==false` 跳过回复且不标记消费
+- **修复**：改为 `c || reply != ""`，只要命令产生了回复内容即视为已处理
+
+### 插件分组命令触发相关性检查
+- **问题**：发送 `/system` 等分组节点命令时仍触发相关性检查
+- **原因**：`HasCommand` 只检查 `Handler != nil`，分组节点无 Handler 被判定为非插件命令
+- **修复**：条件扩展为 `Handler != nil || len(Children) > 0`
+
+### 相关性结果解析失败
+- **问题**：LLM 返回的 JSON 中 reason 含未转义引号导致解析失败，fallback 到 `relevance=0`
+- **修复**：`extractRelevanceJSON` 改用正则提取 `relevance` 和 `reason`，不依赖标准 JSON 解析

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -55,6 +55,9 @@ type HagoCenter struct {
 	SelfQQ       int64
 	SelfNickname string
 
+	// StripMarkdown 缓存回复策略中的去 Markdown 开关（每次 processEvent 刷新）
+	StripMarkdown bool
+
 	// CurrentSessionCtx 当前会话上下文（供 get_session_info 工具使用）
 	CurrentSessionCtx string
 	// CurrentMsg 当前正在处理的消息（供工具获取发送目标）

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -57,6 +57,8 @@ type HagoCenter struct {
 
 	// StripMarkdown 缓存回复策略中的去 Markdown 开关（每次 processEvent 刷新）
 	StripMarkdown bool
+	// DisableSplit 缓存 AgentLite 模式开关，为 true 时 sendReply 不拆分多段消息
+	DisableSplit bool
 
 	// CurrentSessionCtx 当前会话上下文（供 get_session_info 工具使用）
 	CurrentSessionCtx string

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -155,6 +155,9 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 
 	// 后台任务结果事件（Drainer 合成）跳过策略检查，图片等媒体已由 Drainer 直接发送
 	if ev.IsBgTaskResult {
+		if cfg, err := h.DAO.ReplyStrategy.GetOrCreate(ctx); err == nil {
+			h.StripMarkdown = cfg.StripMarkdown
+		}
 		h.handleMessage(ctx, ev)
 		return
 	}
@@ -167,9 +170,12 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 		cfg, err := h.DAO.ReplyStrategy.GetOrCreate(ctx)
 		if err != nil {
 			slog.Warn("获取回复策略失败，跳过过滤", "err", err)
-		} else if cfg.Strategy == models.StrategyNeverReply {
-			slog.Debug("回复策略: 完全不回复，跳过私聊", "user_id", msg.UserID)
-			return
+		} else {
+			h.StripMarkdown = cfg.StripMarkdown
+			if cfg.Strategy == models.StrategyNeverReply {
+				slog.Debug("回复策略: 完全不回复，跳过私聊", "user_id", msg.UserID)
+				return
+			}
 		}
 		// 非完全不回复策略，私聊直接放行
 		h.handleMessage(ctx, ev)
@@ -180,6 +186,7 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 	if err != nil {
 		slog.Warn("获取回复策略失败，跳过过滤", "err", err)
 	} else {
+		h.StripMarkdown = cfg.StripMarkdown
 		switch cfg.Strategy {
 		case models.StrategyNeverReply:
 			// 完全不处理
@@ -614,6 +621,9 @@ func splitMessages(content string) []string {
 }
 
 func (h *HagoCenter) sendReply(msg *adapter.MessageEvent, content string) {
+	if h.StripMarkdown {
+		content = stripMarkdown(content)
+	}
 	for _, part := range splitMessages(content) {
 		var err error
 		switch msg.MessageType {

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -621,10 +621,10 @@ func splitMessages(content string) []string {
 }
 
 func (h *HagoCenter) sendReply(msg *adapter.MessageEvent, content string) {
-	if h.StripMarkdown {
-		content = stripMarkdown(content)
-	}
 	for _, part := range splitMessages(content) {
+		if h.StripMarkdown {
+			part = stripMarkdown(part)
+		}
 		var err error
 		switch msg.MessageType {
 		case "private":

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -157,6 +157,7 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 	if ev.IsBgTaskResult {
 		if cfg, err := h.DAO.ReplyStrategy.GetOrCreate(ctx); err == nil {
 			h.StripMarkdown = cfg.StripMarkdown
+			h.DisableSplit = cfg.AgentLite
 		}
 		h.handleMessage(ctx, ev)
 		return
@@ -172,6 +173,7 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 			slog.Warn("获取回复策略失败，跳过过滤", "err", err)
 		} else {
 			h.StripMarkdown = cfg.StripMarkdown
+			h.DisableSplit = cfg.AgentLite
 			if cfg.Strategy == models.StrategyNeverReply {
 				slog.Debug("回复策略: 完全不回复，跳过私聊", "user_id", msg.UserID)
 				return
@@ -187,6 +189,7 @@ func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
 		slog.Warn("获取回复策略失败，跳过过滤", "err", err)
 	} else {
 		h.StripMarkdown = cfg.StripMarkdown
+		h.DisableSplit = cfg.AgentLite
 		switch cfg.Strategy {
 		case models.StrategyNeverReply:
 			// 完全不处理
@@ -371,9 +374,14 @@ func (h *HagoCenter) handleMessage(ctx context.Context, ev adapter.Event) {
 		Tools:       toolList,
 		Temperature: 0.7,
 	}
-	// AgentLite 模式：不向 LLM 暴露工具
+	// AgentLite 模式：不向 LLM 暴露工具，并注入提示词
 	if agentLite {
 		req.Tools = nil
+		messages = append([]provider.ChatMessage{{
+			Role:    "system",
+			Content: "【AgentLite 模式】当前处于精简模式，你无法使用任何工具或 MCP 调用，也无法分条发送消息。请将所有回复合并为一条消息返回。",
+		}}, messages...)
+		req.Messages = messages
 	}
 
 	resp, err := llm.Chat(ctx, req)
@@ -631,7 +639,13 @@ func splitMessages(content string) []string {
 }
 
 func (h *HagoCenter) sendReply(msg *adapter.MessageEvent, content string) {
-	for _, part := range splitMessages(content) {
+	var parts []string
+	if h.DisableSplit {
+		parts = []string{content}
+	} else {
+		parts = splitMessages(content)
+	}
+	for _, part := range parts {
 		if h.StripMarkdown {
 			part = stripMarkdown(part)
 		}

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -361,10 +361,19 @@ func (h *HagoCenter) handleMessage(ctx context.Context, ev adapter.Event) {
 	// 持久化原始聊天记录到 DB (与短期记忆解耦, 不受 Redis 重启或 Compact 影响)
 	h.Session.AppendRecord(ctx, chatArea.ID, userID, "user", userMsg, 0, nil)
 
+	// 读取回复策略：always 模式跳过静默检测；AgentLite 模式不传工具、跳过工具循环
+	replyCfg, _ := h.DAO.ReplyStrategy.GetOrCreate(ctx)
+	skipSilenceCheck := replyCfg != nil && replyCfg.Strategy == models.StrategyAlways
+	agentLite := replyCfg != nil && replyCfg.AgentLite
+
 	req := provider.ChatRequest{
 		Messages:    messages,
 		Tools:       toolList,
 		Temperature: 0.7,
+	}
+	// AgentLite 模式：不向 LLM 暴露工具
+	if agentLite {
+		req.Tools = nil
 	}
 
 	resp, err := llm.Chat(ctx, req)
@@ -374,10 +383,6 @@ func (h *HagoCenter) handleMessage(ctx context.Context, ev adapter.Event) {
 	}
 
 	h.Session.UpdateTokenUsage(ctx, sess.ID, int64(resp.TokenUsage))
-
-	// 获取回复策略，always 模式下跳过静默检测
-	replyCfg, _ := h.DAO.ReplyStrategy.GetOrCreate(ctx)
-	skipSilenceCheck := replyCfg != nil && replyCfg.Strategy == models.StrategyAlways
 
 	if resp.Message.Content != "" {
 		silenced := !skipSilenceCheck && msg.MessageType == "group" && isSilenceResponse(resp.Message.Content)
@@ -390,6 +395,11 @@ func (h *HagoCenter) handleMessage(ctx context.Context, ev adapter.Event) {
 				h.Memory.AddShortTermMessage(ctx, chatArea.ID, shortterm.ChatMessage{Role: "assistant", Content: resp.Message.Content})
 			}
 		}
+	}
+
+	// AgentLite 模式：跳过所有工具/MCP 调用和 Agent 循环
+	if agentLite {
+		return
 	}
 
 	// 静默响应时也跳过工具调用（防止 LLM 绕过文本输出直接调 send_group_msg 发废话）

--- a/internal/agent/markdown.go
+++ b/internal/agent/markdown.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	mdCodeBlock   = regexp.MustCompile("(?s)```[^`]*```")
+	mdInlineCode  = regexp.MustCompile("`([^`]+)`")
+	mdImage       = regexp.MustCompile(`!\[.*?\]\(.*?\)`)
+	mdLink        = regexp.MustCompile(`\[([^\]]*)\]\(.*?\)`)
+	mdBoldItalic  = regexp.MustCompile(`\*{3}(.+?)\*{3}`)
+	mdBold        = regexp.MustCompile(`\*{2}(.+?)\*{2}`)
+	mdItalic      = regexp.MustCompile(`\*([^*\n]+)\*`)
+	mdStrike      = regexp.MustCompile(`~~(.+?)~~`)
+	mdUnder       = regexp.MustCompile(`__([^_\n]+)__`)
+	mdHeading     = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	mdQuote       = regexp.MustCompile(`(?m)^>\s?`)
+	mdUnordered   = regexp.MustCompile(`(?m)^\s*[-*+]\s+`)
+	mdOrdered     = regexp.MustCompile(`(?m)^\s*\d+\.\s+`)
+	mdHR          = regexp.MustCompile(`(?m)^[-*_]{3,}\s*$`)
+	mdTableSep    = regexp.MustCompile(`(?m)^\|?[-:| ]+\|[-:| ]+\|?$`)
+)
+
+// stripMarkdown 去除 markdown 格式，保留纯文本。
+// 顺序很重要：代码块和图片要先于其他格式处理。
+func stripMarkdown(s string) string {
+	// 代码块：去掉围栏，保留内容
+	s = mdCodeBlock.ReplaceAllStringFunc(s, func(match string) string {
+		// 去掉第一行和最后一行的 ``` 围栏
+		lines := strings.Split(match, "\n")
+		if len(lines) <= 2 {
+			return ""
+		}
+		return strings.Join(lines[1:len(lines)-1], "\n")
+	})
+
+	// 行内代码：保留内容
+	s = mdInlineCode.ReplaceAllString(s, "$1")
+
+	// 图片：移除
+	s = mdImage.ReplaceAllString(s, "[图片]")
+
+	// 链接：保留文字
+	s = mdLink.ReplaceAllString(s, "$1")
+
+	// 粗斜体
+	s = mdBoldItalic.ReplaceAllString(s, "$1")
+	// 粗体
+	s = mdBold.ReplaceAllString(s, "$1")
+	// 斜体
+	s = mdItalic.ReplaceAllString(s, "$1")
+	// 删除线
+	s = mdStrike.ReplaceAllString(s, "$1")
+	// 下划线
+	s = mdUnder.ReplaceAllString(s, "$1")
+
+	// 标题：去掉 # 前缀
+	s = mdHeading.ReplaceAllString(s, "")
+	// 引用：去掉 > 前缀
+	s = mdQuote.ReplaceAllString(s, "")
+	// 无序列表：去掉 - * + 前缀
+	s = mdUnordered.ReplaceAllString(s, "")
+	// 有序列表：去掉数字前缀
+	s = mdOrdered.ReplaceAllString(s, "")
+
+	// 表格分隔行：移除
+	s = mdTableSep.ReplaceAllString(s, "")
+	// 表格竖线：替换为空格
+	s = strings.ReplaceAll(s, "|", " ")
+	// 水平线：移除
+	s = mdHR.ReplaceAllString(s, "")
+
+	// 清理多余空白
+	lines := strings.Split(s, "\n")
+	var clean []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			clean = append(clean, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(clean, "\n"))
+}

--- a/internal/api/dto/request.go
+++ b/internal/api/dto/request.go
@@ -250,4 +250,5 @@ type UpdateReplyStrategyReq struct {
 	Strategy           string  `json:"strategy"`
 	RelevanceThreshold float64 `json:"relevance_threshold"`
 	BotName            string  `json:"bot_name"`
+	StripMarkdown      bool    `json:"strip_markdown"`
 }

--- a/internal/api/dto/request.go
+++ b/internal/api/dto/request.go
@@ -251,4 +251,5 @@ type UpdateReplyStrategyReq struct {
 	RelevanceThreshold float64 `json:"relevance_threshold"`
 	BotName            string  `json:"bot_name"`
 	StripMarkdown      bool    `json:"strip_markdown"`
+	AgentLite          bool    `json:"agent_lite"`
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -302,4 +302,5 @@ type ReplyStrategyResp struct {
 	RelevanceThreshold float64 `json:"relevance_threshold"`
 	BotName            string  `json:"bot_name"`
 	StripMarkdown      bool    `json:"strip_markdown"`
+	AgentLite          bool    `json:"agent_lite"`
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -301,4 +301,5 @@ type ReplyStrategyResp struct {
 	Strategy           string  `json:"strategy"`
 	RelevanceThreshold float64 `json:"relevance_threshold"`
 	BotName            string  `json:"bot_name"`
+	StripMarkdown      bool    `json:"strip_markdown"`
 }

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -1807,6 +1807,7 @@ func (s *Service) GetReplyStrategy(ctx context.Context, c *app.RequestContext) {
 		RelevanceThreshold: cfg.RelevanceThreshold,
 		BotName:            cfg.BotName,
 		StripMarkdown:      cfg.StripMarkdown,
+		AgentLite:          cfg.AgentLite,
 	}))
 }
 
@@ -1851,6 +1852,7 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 	cfg.RelevanceThreshold = data.RelevanceThreshold
 	cfg.BotName = data.BotName
 	cfg.StripMarkdown = data.StripMarkdown
+	cfg.AgentLite = data.AgentLite
 
 	if err := s.DAO.ReplyStrategy.Update(ctx, cfg); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
@@ -1862,6 +1864,7 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 		RelevanceThreshold: cfg.RelevanceThreshold,
 		BotName:            cfg.BotName,
 		StripMarkdown:      cfg.StripMarkdown,
+		AgentLite:          cfg.AgentLite,
 	}))
 }
 

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -1806,6 +1806,7 @@ func (s *Service) GetReplyStrategy(ctx context.Context, c *app.RequestContext) {
 		Strategy:           string(cfg.Strategy),
 		RelevanceThreshold: cfg.RelevanceThreshold,
 		BotName:            cfg.BotName,
+		StripMarkdown:      cfg.StripMarkdown,
 	}))
 }
 
@@ -1849,6 +1850,7 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 	cfg.Strategy = models.ReplyStrategy(data.Strategy)
 	cfg.RelevanceThreshold = data.RelevanceThreshold
 	cfg.BotName = data.BotName
+	cfg.StripMarkdown = data.StripMarkdown
 
 	if err := s.DAO.ReplyStrategy.Update(ctx, cfg); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
@@ -1859,6 +1861,7 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 		Strategy:           string(cfg.Strategy),
 		RelevanceThreshold: cfg.RelevanceThreshold,
 		BotName:            cfg.BotName,
+		StripMarkdown:      cfg.StripMarkdown,
 	}))
 }
 

--- a/internal/core/dao/onebotDao.go
+++ b/internal/core/dao/onebotDao.go
@@ -34,7 +34,7 @@ func (d *Onebot11AdapterDao) GetAdapterConfig(ctx context.Context) (*models.Oneb
 }
 
 func (d *Onebot11AdapterDao) UpdateAdapterConfig(ctx context.Context, conf *models.Onebot11Adapter) error {
-	return d.db.WithContext(ctx).Where("id = 1").Updates(conf).Error
+	return d.db.WithContext(ctx).Where("id = 1").Select("*").Updates(conf).Error
 }
 
 // AddAdminQQ 添加管理员 QQ 号，已存在则忽略。

--- a/internal/core/dao/sandboxDao.go
+++ b/internal/core/dao/sandboxDao.go
@@ -33,6 +33,7 @@ func (d *SandboxConfigDAO) GetConfig(ctx context.Context) (*models.SandboxConfig
 }
 
 // UpdateConfig 更新 Sandbox 配置。
+// 使用 Select("*") 强制更新所有字段（包括 false 等零值），避免 GORM struct Updates 跳过零值字段。
 func (d *SandboxConfigDAO) UpdateConfig(ctx context.Context, conf *models.SandboxConfig) error {
-	return d.db.WithContext(ctx).Where("id = 1").Updates(conf).Error
+	return d.db.WithContext(ctx).Where("id = 1").Select("*").Updates(conf).Error
 }

--- a/internal/core/dao/t2iDao.go
+++ b/internal/core/dao/t2iDao.go
@@ -34,5 +34,5 @@ func (d *T2IConfigDAO) GetConfig(ctx context.Context) (*models.T2IConfig, error)
 
 // UpdateConfig 更新 T2I 配置。
 func (d *T2IConfigDAO) UpdateConfig(ctx context.Context, conf *models.T2IConfig) error {
-	return d.db.WithContext(ctx).Where("id = 1").Updates(conf).Error
+	return d.db.WithContext(ctx).Where("id = 1").Select("*").Updates(conf).Error
 }

--- a/internal/core/dao/webhookDao.go
+++ b/internal/core/dao/webhookDao.go
@@ -36,5 +36,5 @@ func (d *WebhookConfigDAO) GetConfig(ctx context.Context) (*models.WebhookConfig
 
 // UpdateConfig 更新 Webhook 配置。
 func (d *WebhookConfigDAO) UpdateConfig(ctx context.Context, conf *models.WebhookConfig) error {
-	return d.db.WithContext(ctx).Where("id = 1").Updates(conf).Error
+	return d.db.WithContext(ctx).Where("id = 1").Select("*").Updates(conf).Error
 }

--- a/internal/core/models/reply_strategy.go
+++ b/internal/core/models/reply_strategy.go
@@ -19,6 +19,7 @@ type ReplyStrategyConfig struct {
 	Strategy           ReplyStrategy `gorm:"not null;default:'always'" json:"strategy"`
 	RelevanceThreshold float64       `gorm:"default:0.5" json:"relevance_threshold"`
 	BotName            string        `gorm:"default:''" json:"bot_name"`
+	StripMarkdown      bool          `gorm:"default:false" json:"strip_markdown"` // 是否去除 Agent 消息中的 Markdown 格式
 	CreatedAt          time.Time     `json:"created_at"`
 	UpdatedAt          time.Time     `json:"updated_at"`
 }

--- a/internal/core/models/reply_strategy.go
+++ b/internal/core/models/reply_strategy.go
@@ -20,6 +20,7 @@ type ReplyStrategyConfig struct {
 	RelevanceThreshold float64       `gorm:"default:0.5" json:"relevance_threshold"`
 	BotName            string        `gorm:"default:''" json:"bot_name"`
 	StripMarkdown      bool          `gorm:"default:false" json:"strip_markdown"` // 是否去除 Agent 消息中的 Markdown 格式
+	AgentLite          bool          `gorm:"default:false" json:"agent_lite"`    // AgentLite 模式：不调用工具/MCP，无 Agent 循环
 	CreatedAt          time.Time     `json:"created_at"`
 	UpdatedAt          time.Time     `json:"updated_at"`
 }

--- a/internal/pluggin/command.go
+++ b/internal/pluggin/command.go
@@ -137,7 +137,9 @@ func (r *CommandRegistry) HasCommand(raw string) bool {
 			break
 		}
 		cur = next
-		if next.Handler != nil {
+		// 叶节点（有 Handler）或分组节点（有子命令）都视为命中，
+		// 因为 Dispatch 会对两者产生有效输出（执行命令 / 列出子命令）
+		if next.Handler != nil || len(next.Children) > 0 {
 			matched = true
 		}
 	}

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -405,7 +405,8 @@ func (pe *PluginEngine) OnMessage(event EventData) (consumed bool) {
 		if err != nil {
 			slog.Error("命令派发错误", "raw", event.RawMessage, "err", err)
 		}
-		if c {
+		// 只要命令已消费或有回复内容，都视为已处理（避免消息流入 Agent）
+		if c || reply != "" {
 			if reply != "" {
 				pe.sendReply(event, reply)
 			}

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -224,11 +224,13 @@ export interface ReplyStrategyResp {
   strategy: string
   relevance_threshold: number
   bot_name: string
+  strip_markdown: boolean
 }
 export interface UpdateReplyStrategyReq {
   strategy: string
   relevance_threshold: number
   bot_name: string
+  strip_markdown: boolean
 }
 
 export const replyStrategyApi = {

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -225,12 +225,14 @@ export interface ReplyStrategyResp {
   relevance_threshold: number
   bot_name: string
   strip_markdown: boolean
+  agent_lite: boolean
 }
 export interface UpdateReplyStrategyReq {
   strategy: string
   relevance_threshold: number
   bot_name: string
   strip_markdown: boolean
+  agent_lite: boolean
 }
 
 export const replyStrategyApi = {

--- a/web/src/layouts/AppSidebar.vue
+++ b/web/src/layouts/AppSidebar.vue
@@ -73,7 +73,7 @@ const navGroups = [
     title: '核心配置',
     icon: 'mdi-cog-outline',
     items: [
-      { title: '回复策略', icon: 'mdi-reply-circle', to: '/reply-strategy' },
+      { title: '回复设置', icon: 'mdi-reply-circle', to: '/reply-strategy' },
       { title: 'Adapter', icon: 'mdi-connection', to: '/adapter' },
       { title: 'LLM Providers', icon: 'mdi-brain', to: '/providers' },
       { title: 'MCP 服务器', icon: 'mdi-server-network', to: '/mcp' },

--- a/web/src/views/ReplyStrategyPage.vue
+++ b/web/src/views/ReplyStrategyPage.vue
@@ -1,18 +1,19 @@
 <template>
   <div>
     <div class="page-header">
-      <div class="page-title"><v-icon class="me-2" color="primary">mdi-reply-circle</v-icon>系统回复策略</div>
-      <div class="page-subtitle">控制机器人在群聊和私聊中的回复行为</div>
+      <div class="page-title"><v-icon class="me-2" color="primary">mdi-reply-circle</v-icon>系统回复设置</div>
+      <div class="page-subtitle">控制机器人的回复行为与消息格式</div>
     </div>
 
     <v-row>
       <v-col cols="12" md="8">
-        <v-card rounded="lg" elevation="1">
+        <!-- 回复策略卡片 -->
+        <v-card rounded="lg" elevation="1" class="mb-6">
           <v-card-item>
             <template #title><span class="text-h6 font-weight-bold">回复策略</span></template>
           </v-card-item>
           <v-card-text>
-            <v-form @submit.prevent="handleSave" ref="formRef">
+            <v-form @submit.prevent="handleSave">
               <v-radio-group v-model="form.strategy" class="mb-4">
                 <v-radio label="完全不回复 — 不处理任何消息" value="never_reply" color="error" />
                 <v-radio label="仅@我时回复 — 只有被@时才交给 Plugin 和 Agent" value="at_only" color="warning" />
@@ -76,6 +77,32 @@
             </v-form>
           </v-card-text>
         </v-card>
+
+        <!-- 其他设置卡片 -->
+        <v-card rounded="lg" elevation="1">
+          <v-card-item>
+            <template #title><span class="text-h6 font-weight-bold">其他设置</span></template>
+          </v-card-item>
+          <v-card-text>
+            <v-form @submit.prevent="handleSave">
+              <v-switch
+                v-model="form.strip_markdown"
+                label="去除 Markdown 格式 — Agent 发送消息前去除加粗、斜体、代码块等格式"
+                color="primary"
+                hide-details
+                class="mb-2"
+              />
+              <div class="text-caption text-medium-emphasis mb-4">
+                开启后，Agent 回复中的 **加粗**、*斜体*、`代码`、[链接]、标题、列表 等 Markdown
+                格式将被去除，发送纯文本到 QQ。
+              </div>
+
+              <v-btn type="submit" color="primary" variant="tonal" :loading="saving">
+                <v-icon class="me-1">mdi-content-save</v-icon> 保存设置
+              </v-btn>
+            </v-form>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
   </div>
@@ -93,6 +120,7 @@ const form = ref({
   strategy: 'always',
   relevance_threshold: 0.5,
   bot_name: '',
+  strip_markdown: false,
 })
 
 async function load() {
@@ -103,6 +131,7 @@ async function load() {
       form.value.strategy = d.strategy || 'always'
       form.value.relevance_threshold = d.relevance_threshold ?? 0.5
       form.value.bot_name = d.bot_name || ''
+      form.value.strip_markdown = d.strip_markdown || false
     }
   } catch (_e: any) {}
 }
@@ -114,8 +143,9 @@ async function handleSave() {
       strategy: form.value.strategy,
       relevance_threshold: form.value.relevance_threshold,
       bot_name: form.value.bot_name,
+      strip_markdown: form.value.strip_markdown,
     })
-    toastStore.success('回复策略已保存')
+    toastStore.success('回复设置已保存')
   } catch (e: any) {
     toastStore.error(e?.response?.data?.info || e?.message || '保存失败')
   } finally { saving.value = false }

--- a/web/src/views/ReplyStrategyPage.vue
+++ b/web/src/views/ReplyStrategyPage.vue
@@ -6,11 +6,12 @@
     </div>
 
     <v-row>
-      <v-col cols="12" md="8">
-        <!-- 回复策略卡片 -->
-        <v-card rounded="lg" elevation="1" class="mb-6">
+      <!-- 回复策略 -->
+      <v-col cols="12" md="7">
+        <v-card rounded="lg" elevation="1" class="h-100">
           <v-card-item>
             <template #title><span class="text-h6 font-weight-bold">回复策略</span></template>
+            <template #subtitle>群聊/私聊消息路由方式</template>
           </v-card-item>
           <v-card-text>
             <v-form @submit.prevent="handleSave">
@@ -28,24 +29,13 @@
                   <div class="d-flex align-center" style="gap: 16px">
                     <v-slider
                       v-model="form.relevance_threshold"
-                      :min="0"
-                      :max="1"
-                      :step="0.05"
-                      color="primary"
-                      thumb-label="always"
-                      hide-details
-                      style="flex: 1"
+                      :min="0" :max="1" :step="0.05"
+                      color="primary" thumb-label="always" hide-details style="flex: 1"
                     />
                     <v-text-field
                       v-model.number="form.relevance_threshold"
-                      type="number"
-                      :min="0"
-                      :max="1"
-                      :step="0.05"
-                      density="compact"
-                      style="width: 90px"
-                      hide-details
-                      variant="outlined"
+                      type="number" :min="0" :max="1" :step="0.05"
+                      density="compact" style="width: 90px" hide-details variant="outlined"
                     />
                   </div>
                   <div class="text-caption text-medium-emphasis mt-2">
@@ -58,47 +48,57 @@
                   <div class="text-subtitle-2 font-weight-bold mb-2">机器人名字</div>
                   <v-text-field
                     v-model="form.bot_name"
-                    label="机器人名字（用于相关性判断，如「小卷」）"
+                    label="用于相关性判断，如「小卷」"
                     placeholder="例如：小卷"
-                    density="comfortable"
-                    variant="outlined"
-                    hide-details
-                    clearable
+                    density="comfortable" variant="outlined" hide-details clearable
                   />
-                  <div class="text-caption text-medium-emphasis mt-2">
-                    设置机器人名字后，相关性检查会参考此名字来判断消息是否指向机器人。
-                  </div>
                 </v-card>
               </v-expand-transition>
 
               <v-btn type="submit" color="primary" variant="tonal" :loading="saving" :disabled="!form.strategy">
-                <v-icon class="me-1">mdi-content-save</v-icon> 保存策略
+                <v-icon class="me-1">mdi-content-save</v-icon> 保存
               </v-btn>
             </v-form>
           </v-card-text>
         </v-card>
+      </v-col>
 
-        <!-- 其他设置卡片 -->
-        <v-card rounded="lg" elevation="1">
+      <!-- 其他设置 -->
+      <v-col cols="12" md="5">
+        <v-card rounded="lg" elevation="1" class="h-100">
           <v-card-item>
             <template #title><span class="text-h6 font-weight-bold">其他设置</span></template>
+            <template #subtitle>消息格式与 Agent 行为</template>
           </v-card-item>
           <v-card-text>
             <v-form @submit.prevent="handleSave">
-              <v-switch
-                v-model="form.strip_markdown"
-                label="去除 Markdown 格式 — Agent 发送消息前去除加粗、斜体、代码块等格式"
-                color="primary"
-                hide-details
-                class="mb-2"
-              />
-              <div class="text-caption text-medium-emphasis mb-4">
-                开启后，Agent 回复中的 **加粗**、*斜体*、`代码`、[链接]、标题、列表 等 Markdown
-                格式将被去除，发送纯文本到 QQ。
+              <!-- AgentLite -->
+              <div class="d-flex align-start mb-4">
+                <div class="flex-grow-1 me-3">
+                  <div class="text-subtitle-2 font-weight-bold">AgentLite 模式</div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    关闭工具/MCP 调用和 Agent 循环。消息直接发给 LLM，回复后即结束。<br />
+                    记忆、提示词、Skill 行为不受影响。
+                  </div>
+                </div>
+                <v-switch v-model="form.agent_lite" color="primary" hide-details density="compact" />
+              </div>
+
+              <v-divider class="mb-4" />
+
+              <!-- Strip Markdown -->
+              <div class="d-flex align-start mb-4">
+                <div class="flex-grow-1 me-3">
+                  <div class="text-subtitle-2 font-weight-bold">去除 Markdown 格式</div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    Agent 发送消息前去除加粗、斜体、代码块、链接等格式，发送纯文本到 QQ。
+                  </div>
+                </div>
+                <v-switch v-model="form.strip_markdown" color="primary" hide-details density="compact" />
               </div>
 
               <v-btn type="submit" color="primary" variant="tonal" :loading="saving">
-                <v-icon class="me-1">mdi-content-save</v-icon> 保存设置
+                <v-icon class="me-1">mdi-content-save</v-icon> 保存
               </v-btn>
             </v-form>
           </v-card-text>
@@ -121,6 +121,7 @@ const form = ref({
   relevance_threshold: 0.5,
   bot_name: '',
   strip_markdown: false,
+  agent_lite: false,
 })
 
 async function load() {
@@ -132,6 +133,7 @@ async function load() {
       form.value.relevance_threshold = d.relevance_threshold ?? 0.5
       form.value.bot_name = d.bot_name || ''
       form.value.strip_markdown = d.strip_markdown || false
+      form.value.agent_lite = d.agent_lite || false
     }
   } catch (_e: any) {}
 }
@@ -144,6 +146,7 @@ async function handleSave() {
       relevance_threshold: form.value.relevance_threshold,
       bot_name: form.value.bot_name,
       strip_markdown: form.value.strip_markdown,
+      agent_lite: form.value.agent_lite,
     })
     toastStore.success('回复设置已保存')
   } catch (e: any) {


### PR DESCRIPTION
### 新功能
AgentLite 模式

- 精简模式：不暴露工具/MCP 给 LLM，跳过 Agent 循环，LLM 直接回复后结束
- 注入 system 提示词告知 LLM 当前限制，同时关闭分条回复
- 记忆/提示词/Skill 行为不变，回复仍写回记忆
- 开关位于 Web 面板「回复设置 → 其他设置」
Markdown 去除工具

- Agent 发送消息前剥离加粗、斜体、代码块、链接、标题、列表、表格等格式
- 修复了 | 替换破坏 <|msg|> 分隔符导致分条回复失效的问题
- 开关位于 Web 面板「回复设置 → 其他设置」
回复设置页面重构

- 原「核心配置 - 回复策略」改名为「回复设置」
- 左右双列卡片布局：回复策略 + 其他设置
### Bug 修复
#### Web 关闭沙箱后 DB 不同步

- 原因：GORM Updates(struct) 跳过 bool 零值字段， IsActive: false 永远写不进 DB，重启后状态丢失
- 修复：sandboxDao、onebotDao、webhookDao、t2iDao 所有 Updates 调用加 Select("*") 强制更新全部字段

#### 插件命令被路由给 Agent

- 原因：Lua 插件 handler 未返回 consumed 时默认 false ， OnMessage 因 c==false 跳过回复且不标记消费，消息落入 Agent
- 修复：改为 c || reply != "" ，只要命令产生了回复内容即视为已处理

#### 分组命令 /system 触发相关性检查

- 原因： HasCommand 只检查 Handler != nil ，分组节点无 Handler 被判定为非插件命令
- 修复：条件扩展为 Handler != nil || len(Children) > 0

#### 去 Markdown 破坏分条回复

- 原因： stripMarkdown 中 |→空格 替换会破坏 <|msg|> 分隔符，导致 splitMessages 无法拆分
- 修复：改为先 splitMessages 拆分，再对每条消息独立执行 stripMarkdown