### PR TITLE
feat: CronJob Plugin 分发 + 插件重载 + CodeMirror JSON 编辑器

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -149,6 +149,9 @@ func main() {
 	}
 	hago.PluginEngine = pluginEngine
 
+	// 将 PluginEngine 的 OnTimerCall 注入 CronJob 调度器
+	hago.CronJobManager.SetPluginTimer(pluginEngine, adapterCfg.Admins)
+
 	// ---------- 7. Web API ----------
 
 	svc := service.New(coreInst.DAO, adapterProv, webhookAdapter, pluginEngine)

--- a/data/pluggins/cron-example/main.lua
+++ b/data/pluggins/cron-example/main.lua
@@ -1,0 +1,49 @@
+-- ====================================================================
+-- Cron 示例插件
+-- ====================================================================
+-- 当 CronJob 触发此插件时，on_timer_call(event) 被调用。
+-- event.payload 即 CronJob 配置的 Payload JSON 对象。
+--
+-- 示例 Payload:
+--   {
+--     "target_qq": 123456789,
+--     "message": "⏰ 定时提醒：该喝水啦！",
+--     "message_type": "private"
+--   }
+--
+-- 字段说明:
+--   target_qq    (number, 必填) 目标 QQ 号
+--   message      (string, 必填) 发送的消息文本
+--   message_type (string, 可选) "private"(默认) 或 "group"
+--   group_id     (number, 可选) message_type=group 时的群号
+-- ====================================================================
+
+local jn = require("jn")
+
+--- 定时任务回调
+---@param event jn.Event
+function on_timer_call(event)
+    local payload = event.payload or {}
+    local target_qq = payload.target_qq
+    local message = payload.message
+    local msg_type = payload.message_type or "private"
+    local group_id = payload.group_id
+
+    -- 参数校验
+    if not target_qq or not message then
+        jn.log.error("[cron-example] Payload 缺少必填字段 target_qq 或 message")
+        return
+    end
+
+    if msg_type == "group" then
+        if not group_id then
+            jn.log.error("[cron-example] message_type=group 需要提供 group_id")
+            return
+        end
+        jn.onebot11.send_group_msg(group_id, message)
+        jn.log.info(string.format("[cron-example] 已向群 %d 发送定时消息", group_id))
+    else
+        jn.onebot11.send_private_msg(target_qq, message)
+        jn.log.info(string.format("[cron-example] 已向 QQ %d 发送定时消息", target_qq))
+    end
+end

--- a/data/pluggins/cron-example/main.lua
+++ b/data/pluggins/cron-example/main.lua
@@ -20,7 +20,7 @@
 
 local jn = require("jn")
 
---- 定时任务回调
+-- 定时任务回调
 ---@param event jn.Event
 function on_timer_call(event)
     local payload = event.payload or {}
@@ -30,8 +30,8 @@ function on_timer_call(event)
     local group_id = payload.group_id
 
     -- 参数校验
-    if not target_qq or not message then
-        jn.log.error("[cron-example] Payload 缺少必填字段 target_qq 或 message")
+    if not message then
+        jn.log.error("[cron-example] Payload 缺少必填字段 message")
         return
     end
 
@@ -43,6 +43,10 @@ function on_timer_call(event)
         jn.onebot11.send_group_msg(group_id, message)
         jn.log.info(string.format("[cron-example] 已向群 %d 发送定时消息", group_id))
     else
+        if not target_qq then
+            jn.log.error("[cron-example] message_type=private 需要提供 target_qq")
+            return
+        end
         jn.onebot11.send_private_msg(target_qq, message)
         jn.log.info(string.format("[cron-example] 已向 QQ %d 发送定时消息", target_qq))
     end

--- a/data/pluggins/cron-example/pluggin.yaml
+++ b/data/pluggins/cron-example/pluggin.yaml
@@ -1,10 +1,10 @@
-# cron-example 插件清单
-name: "Cron 示例插件"
-version: "1.0.0"
-author: "JuanNiang"
-description: "示例插件：通过 CronJob 定时触发，向 Payload 中指定的 QQ 号发送消息"
-entry: "main.lua"
+ppid: a49cd506-b50a-4dd4-bbb0-7bee2c76b6bd
+name: Cron 示例插件
+version: 1.0.0
+author: JuanNiang
+description: 示例插件：通过 CronJob 定时触发，向 Payload 中指定的 QQ 号发送消息
+entry: main.lua
 permissions:
-  - onebot11
+    - onebot11
 system: false
 enabled: true

--- a/data/pluggins/cron-example/pluggin.yaml
+++ b/data/pluggins/cron-example/pluggin.yaml
@@ -1,0 +1,10 @@
+# cron-example 插件清单
+name: "Cron 示例插件"
+version: "1.0.0"
+author: "JuanNiang"
+description: "示例插件：通过 CronJob 定时触发，向 Payload 中指定的 QQ 号发送消息"
+entry: "main.lua"
+permissions:
+  - onebot11
+system: false
+enabled: true

--- a/data/pluggins/sdk/jn.lua
+++ b/data/pluggins/sdk/jn.lua
@@ -19,14 +19,15 @@ local M = {}
 -- 事件类型
 -- ====================================================================
 
----@class jn.Event OneBot11 消息事件
----@field post_type string 事件类型 ("message")
+---@class jn.Event OneBot11 消息/定时/webhook 事件
+---@field post_type string 事件类型 ("message" | "timer" | "webhook")
 ---@field message_type string "private" | "group"
 ---@field user_id number 发送者 QQ 号
 ---@field group_id number 群号 (private 时为 0)
 ---@field raw_message string 原始消息文本
 ---@field admins string[] 系统管理员 QQ 号列表
 ---@field webhook table? webhook 事件专属字段
+---@field payload table? on_timer_call 携带的 CronJob payload
 
 -- ====================================================================
 -- log 日志

--- a/data/pluggins/system/main.lua
+++ b/data/pluggins/system/main.lua
@@ -166,16 +166,10 @@ jn.command.register("system mcp", function(args, event)
         reply(event, "获取 MCP 失败: " .. tostring(err))
         return true
     end
-    local lines = {"MCP 服务器列表:"}
+    local lines = {"运行时 MCP 列表:"}
     for _, m in ipairs(list) do
-        local status = m.is_active and "已启用" or "已停用"
-        if m.is_active and m.active then
-            status = "已连接"
-        elseif m.is_active and not m.active then
-            status = "已启用(未连接)"
-        end
-        lines[#lines+1] = string.format("- id=%s  name=%s  %s",
-            m.id, m.name, status)
+        lines[#lines+1] = string.format("- id=%s  name=%s  active=%s",
+            m.id, m.name, tostring(m.active))
     end
     if #list == 0 then
         lines[#lines+1] = "(空)"
@@ -185,7 +179,7 @@ jn.command.register("system mcp", function(args, event)
     reply(event, table.concat(lines, "\n"))
     return true
 end, {
-    description = "管理 MCP 服务器（默认列出全部）",
+    description = "管理 MCP 服务器（默认列出）",
     usage = "/system mcp [list|toggle <id> <on|off>]",
 })
 
@@ -198,16 +192,10 @@ jn.command.register("system mcp list", function(args, event)
         reply(event, "获取 MCP 失败: " .. tostring(err))
         return true
     end
-    local lines = {"MCP 服务器列表:"}
+    local lines = {"运行时 MCP 列表:"}
     for _, m in ipairs(list) do
-        local status = m.is_active and "已启用" or "已停用"
-        if m.is_active and m.active then
-            status = "已连接"
-        elseif m.is_active and not m.active then
-            status = "已启用(未连接)"
-        end
-        lines[#lines+1] = string.format("- id=%s  name=%s  %s",
-            m.id, m.name, status)
+        lines[#lines+1] = string.format("- id=%s  name=%s  active=%s",
+            m.id, m.name, tostring(m.active))
     end
     if #list == 0 then
         lines[#lines+1] = "(空)"
@@ -215,7 +203,7 @@ jn.command.register("system mcp list", function(args, event)
     reply(event, table.concat(lines, "\n"))
     return true
 end, {
-    description = "列出全部 MCP 服务器及其状态",
+    description = "列出运行时 MCP 服务器",
     usage = "/system mcp list",
 })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -445,6 +445,11 @@ curl -X POST http://localhost:8090/api/v1/plugins/upload \
 ### DELETE /plugins/:id
 卸载并删除插件配置（**不删磁盘文件**）。系统插件禁删（40028）。**data** `null`。
 
+### POST /plugins/reload
+**热重载所有非系统插件**。先卸载全部非系统插件，再调用 `LoadAll()` 重新扫描并加载。
+适用于：新增/修改 `on_timer_call` 或注册了新命令后无需重启进程即可生效。
+**Body** 无。**data** `null`。
+
 ---
 
 ## 12. 聊天记录

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -498,6 +498,36 @@ function on_webhook(event)
 end
 ```
 
+## 回调: `on_timer_call`
+
+定时任务回调，由 CronJob 的 Plugin 分发模式触发。
+
+```lua
+function on_timer_call(event)  -- 无返回值
+```
+
+| event 字段 | 类型 | 说明 |
+|----------|------|------|
+| `post_type` | string | `"timer"` |
+| `payload` | table | CronJob 配置的 Payload JSON 对象 |
+| `admins` | []string | admin QQ 列表 |
+
+- 只有定义了 `on_timer_call` 全局函数且已加载的插件才会被 CronJob 调用
+- 前端多选下拉框自动过滤 `supports_timer=true` 的已启用插件
+- 新增/修改 `on_timer_call` 后需通过前端"重载全部"或 `POST /api/v1/plugins/reload` 热重载
+
+```lua
+-- 示例：向 Payload 指定的 QQ 发定时消息
+function on_timer_call(event)
+    local p = event.payload or {}
+    if p.target_qq and p.message then
+        jn.onebot11.send_private_msg(p.target_qq, p.message)
+    end
+end
+```
+
+完整示例见 `data/pluggins/cron-example/`。
+
 ## 权限速查
 
 | 权限 | 暴露的全局表 |
@@ -511,6 +541,7 @@ end
 | `sandbox` | `sandbox.*` |
 | `agent` | `agent.*` |
 | (webhook 调用层过滤) | `on_webhook` 会被调用 |
+| (timer 调用层过滤) | `on_timer_call` 会被调用 |
 
 ---
 

--- a/docs/webhook-cronjob.md
+++ b/docs/webhook-cronjob.md
@@ -104,9 +104,47 @@ curl -X POST http://localhost:8091/webhook \
 
 ### 用途
 
-让 Agent 定时"被提醒发消息"。每个 CronJob 存 `cron_expr` + `message` + `MessageType`（`private`/`group`）+ `TargetID`（QQ 号或群号）。到点时 `CronJobManager.makeJobFunc` 构造一个合成 `Event{PostType:"cronjob", IsCronJob:true}`，注入主 EventLoop，走 `handleMessage` 标准路径——Agent 把 `message` 当用户输入处理。
+CronJob 支持**两种分发模式**，可独立或同时使用：
+
+| 模式 | 字段 | 说明 |
+|------|------|------|
+| **Agent 分发** | `message` + `message_type` + `target_id` | 定时向 Agent 注入一条消息，Agent 将其作为用户输入处理并回复（原有行为） |
+| **Plugin 分发** | `plugin_ids` + `payload` | 定时触发指定插件的 `on_timer_call(event)` 回调，传递 JSON payload |
+
+当 `message` 为空时不发给 Agent，当 `plugin_ids` 为空时不触发插件。两者可同时配置。
+
+#### Agent 分发
+
+到点时 `CronJobManager.makeJobFunc` 构造一个合成 `Event{PostType:"cronjob", IsCronJob:true}`，注入主 EventLoop，走 `handleMessage` 标准路径——Agent 把 `message` 当用户输入处理。
 
 合成事件会**跳过回复策略与 ACL**（`event.go:150`），因为这是系统主动任务，必须回复。
+
+#### Plugin 分发
+
+到点时 `CronJobManager.makeJobFunc` 解析 `plugin_ids`（插件目录名列表），调用 `PluginEngine.OnTimerCall()`。只有**已加载且定义了 `on_timer_call` 全局函数**的插件会被调用。`payload` 作为 JSON 对象传入 `event.payload`。
+
+前端"定时任务"页面在新建/编辑时通过 Tab 切换 Agent/Plugin 模式，Plugin 模式下多选下拉框自动过滤显示 `supports_timer=true` 的已启用插件。
+
+检测方式：运行时检查插件 Lua 全局 `on_timer_call` 是否为函数 → `ListMaps()` 返回 `supports_timer: bool`。
+
+**示例插件**：`data/pluggins/cron-example/` 提供了一个完整的定时触发示例——向 payload 中指定的 QQ 号或群发送消息。
+
+示例 Payload（私聊）：
+```json
+{
+  "target_qq": 123456789,
+  "message": "⏰ 定时提醒：该喝水啦！"
+}
+```
+
+示例 Payload（群聊）：
+```json
+{
+  "message_type": "group",
+  "group_id": 123456,
+  "message": "⏰ 群每日播报：今日天气..."
+}
+```
 
 ### Cron 表达式
 
@@ -133,9 +171,9 @@ curl -X POST http://localhost:8091/webhook \
 | `DELETE` | `/api/v1/cronjobs/:id` | 删除（自动 reload） |
 | `PUT` | `/api/v1/cronjobs/:id/toggle` | 启停（自动 reload） |
 
-`AddCronJobReq` body 字段：`name`、`cron_expr`、`message`、`message_type`（默认 `private`）、`target_id`、`is_active`。
+`AddCronJobReq` body 字段：`name`、`cron_expr`、`message`（可选，空则不发给 Agent）、`message_type`（默认 `private`）、`target_id`、`is_active`、`plugin_ids`（`string[]`，可选）、`payload`（JSON 字符串，可选）。
 
-### 示例：每天早上 9 点私聊提醒
+### 示例：每天早上 9 点私聊提醒（Agent 分发）
 
 ```bash
 curl -X POST http://localhost:8090/api/v1/cronjobs \
@@ -150,7 +188,7 @@ curl -X POST http://localhost:8090/api/v1/cronjobs \
   }'
 ```
 
-### 示例：群每日播报
+### 示例：群每日播报（Agent 分发）
 
 ```bash
 curl -X POST http://localhost:8090/api/v1/cronjobs \
@@ -165,10 +203,25 @@ curl -X POST http://localhost:8090/api/v1/cronjobs \
   }'
 ```
 
+### 示例：每 10 秒触发插件发消息（Plugin 分发）
+
+```bash
+curl -X POST http://localhost:8090/api/v1/cronjobs \
+  -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
+  -d '{
+    "name": "定时通知",
+    "cron_expr": "*/10 * * * * *",
+    "plugin_ids": ["cron-example"],
+    "payload": "{\"target_qq\":123456789,\"message\":\"每10秒的提醒\"}",
+    "is_active": true
+  }'
+```
+
 到点后 Agent 会接到一条"群 987654321 发来消息 '今天有什么新闻？'"，按它能力回复。`message` 等同用户输入，会被 LLM 处理并可调工具（如 `browser_search`）。
 
 ### 运行时流（细节）
 
+**Agent 分发路径**（`message` 非空）：
 ```
 robfig/cron 到期 → CronJobManager.makeJobFunc(job)
   ├─ DAO.CronJob.UpdateLastRun(now, err)
@@ -182,6 +235,19 @@ EventLoop 分支5 → processEvent (PostType=="cronjob") → handleMessage
   跳过策略与 ACL，正常 SendMessage 给 LLM，LLM 可调工具再 sendReply
 ```
 
+**Plugin 分发路径**（`plugin_ids` 非空）：
+```
+robfig/cron 到期 → CronJobManager.makeJobFunc(job)
+  ├─ DAO.CronJob.UpdateLastRun(now, err)
+  ├─ 解析 plugin_ids JSON → []string
+  ├─ 解析 payload JSON → map[string]any
+  └─ PluginTimerDispatcher.OnTimerCall(pluginIDs, payload, admins)
+     └─ PluginEngine.OnTimerCall → 遍历指定插件
+        └─ 调用 Lua on_timer_call(event) （event.payload = payload）
+```
+
+两种路径**相互独立**：若同时配置则都会执行。
+
 `LastRunAt`/`LastError` 回写 DB，前端"定时任务"页可看历史。删改/toggle 后由 `Service.AddCronJob/...` 调 `CronJobManager.Reload()` 同步调度器，无需重启进程。
 
 ### 注意
@@ -191,6 +257,9 @@ EventLoop 分支5 → processEvent (PostType=="cronjob") → handleMessage
 - **Token 计费**：CronJob 触发的消息也走 Session，按账记 `TokenUsage`
 - **跨容器时区**：`TZ=Asia/Shanghai` 容器内是北京时间；裸机部署注意主机时区
 - **target 必须 ChatArea 已存在**：`GetOrCreate` 会自动按 (type, targetID) 创建新 ChatArea，所以首次触发 Session 是新建的（无短期历史）
+- **Plugin 调用的检测**：只有定义了 `on_timer_call` 全局函数且已加载的插件才会被调用；前端多选下拉框自动过滤
+- **Plugin Payload**：必须是合法 JSON 字符串，保存时前端 CodeMirror 编辑器会实时校验格式
+- **插件重载**：`POST /api/v1/plugins/reload` 可热重载全部非系统插件，新增/修改 `on_timer_call` 后需重载才生效
 
 ## 二者结合场景
 

--- a/internal/agent/cronjob/manager.go
+++ b/internal/agent/cronjob/manager.go
@@ -2,6 +2,7 @@ package cronjob
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"sync"
 	"time"
@@ -9,14 +10,23 @@ import (
 	"JuanNiang-Neo/internal/adapter"
 	"JuanNiang-Neo/internal/core/dao"
 	"JuanNiang-Neo/internal/core/models"
+
 	"github.com/robfig/cron/v3"
 )
 
+// PluginTimerDispatcher 定时任务触发插件回调的接口。
+// 由 PluginEngine 实现，在 cronjob 包中通过接口解耦。
+type PluginTimerDispatcher interface {
+	OnTimerCall(pluginIDs []string, payload map[string]any, admins []string)
+}
+
 // Manager 管理定时任务的生命周期与向 Agent 注入事件。
 type Manager struct {
-	cron      *cron.Cron
-	dao       *dao.CronJobDAO
-	eventChan chan adapter.Event // 向 Agent 事件循环发送合成事件
+	cron             *cron.Cron
+	dao              *dao.CronJobDAO
+	eventChan        chan adapter.Event // 向 Agent 事件循环发送合成事件
+	pluginDispatcher PluginTimerDispatcher
+	admins           []string
 
 	mu      sync.RWMutex
 	entries map[string]cron.EntryID // cronJobID → entryID
@@ -33,6 +43,12 @@ func New(d *dao.CronJobDAO, eventChan chan adapter.Event) *Manager {
 		eventChan: eventChan,
 		entries:   make(map[string]cron.EntryID),
 	}
+}
+
+// SetPluginTimer 设置插件定时回调分发器及管理员列表。
+func (m *Manager) SetPluginTimer(dispatcher PluginTimerDispatcher, admins []string) {
+	m.pluginDispatcher = dispatcher
+	m.admins = admins
 }
 
 // Run 加载所有启用的定时任务并启动调度器。
@@ -87,7 +103,8 @@ func (m *Manager) reloadAll() {
 	}
 }
 
-// makeJobFunc 返回一个闭包：触发时构造 Event 并注入到 Agent 事件循环。
+// makeJobFunc 返回一个闭包：触发时构造 Event 并注入到 Agent 事件循环，
+// 同时可选地将事件分发给插件 on_timer_call。
 func (m *Manager) makeJobFunc(job *models.CronJob) func() {
 	return func() {
 		slog.Info("CronJob 触发", "name", job.Name, "msg_type", job.MessageType, "target", job.TargetID)
@@ -95,6 +112,29 @@ func (m *Manager) makeJobFunc(job *models.CronJob) func() {
 		// 更新最后执行时间
 		if err := m.dao.UpdateLastRun(context.Background(), job.ID, time.Now(), ""); err != nil {
 			slog.Warn("CronJob: 更新 last_run_at 失败", "name", job.Name, "err", err)
+		}
+
+		// 1. 如果有 PluginIDs，分发给插件 on_timer_call
+		if job.PluginIDs != "" && m.pluginDispatcher != nil {
+			var pluginIDs []string
+			if err := json.Unmarshal([]byte(job.PluginIDs), &pluginIDs); err != nil {
+				slog.Warn("CronJob: 解析 plugin_ids 失败", "name", job.Name, "plugin_ids", job.PluginIDs, "err", err)
+			} else if len(pluginIDs) > 0 {
+				var payload map[string]any
+				if job.Payload != "" {
+					if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+						slog.Warn("CronJob: 解析 payload 失败，使用空 payload", "name", job.Name, "payload", job.Payload, "err", err)
+						payload = make(map[string]any)
+					}
+				}
+				m.pluginDispatcher.OnTimerCall(pluginIDs, payload, m.admins)
+				slog.Info("CronJob 已分发给插件", "name", job.Name, "plugins", pluginIDs)
+			}
+		}
+
+		// 2. 如果 Message 非空，发送给 Agent（保持向后兼容）
+		if job.Message == "" {
+			return
 		}
 
 		// 构造 MessageEvent（模拟 OneBot11 消息事件）
@@ -110,10 +150,10 @@ func (m *Manager) makeJobFunc(job *models.CronJob) func() {
 		}
 
 		ev := adapter.Event{
-			PostType:    "cronjob",
-			IsCronJob:   true,
-			Message:     msg,
-			Time:        time.Now().Unix(),
+			PostType:  "cronjob",
+			IsCronJob: true,
+			Message:   msg,
+			Time:      time.Now().Unix(),
 		}
 
 		// 非阻塞发送到 Agent 事件循环

--- a/internal/api/dto/request.go
+++ b/internal/api/dto/request.go
@@ -141,17 +141,17 @@ type UpdateSkillReq struct {
 // ---------- Prompt ----------
 
 type AddPromptReq struct {
-	Name      string            `json:"name"`
-	Content   string            `json:"content"`
-	Type      models.PromptType `json:"type"`
-	IsActive  bool              `json:"is_active"`
+	Name     string            `json:"name"`
+	Content  string            `json:"content"`
+	Type     models.PromptType `json:"type"`
+	IsActive bool              `json:"is_active"`
 }
 
 type UpdatePromptReq struct {
-	Name      string            `json:"name"`
-	Content   string            `json:"content"`
-	Type      models.PromptType `json:"type"`
-	IsActive  bool              `json:"is_active"`
+	Name     string            `json:"name"`
+	Content  string            `json:"content"`
+	Type     models.PromptType `json:"type"`
+	IsActive bool              `json:"is_active"`
 }
 
 type TogglePromptReq struct {
@@ -223,21 +223,25 @@ type UpdateWebhookConfigReq struct {
 // ---------- CronJob ----------
 
 type AddCronJobReq struct {
-	Name        string `json:"name"`
-	CronExpr    string `json:"cron_expr"`
-	Message     string `json:"message"`
-	MessageType string `json:"message_type"`
-	TargetID    int64  `json:"target_id"`
-	IsActive    bool   `json:"is_active"`
+	Name        string   `json:"name"`
+	CronExpr    string   `json:"cron_expr"`
+	Message     string   `json:"message"`
+	MessageType string   `json:"message_type"`
+	TargetID    int64    `json:"target_id"`
+	IsActive    bool     `json:"is_active"`
+	PluginIDs   []string `json:"plugin_ids"` // 触发时调用的插件目录名列表
+	Payload     string   `json:"payload"`    // JSON 字符串：传给 on_timer_call 的 payload
 }
 
 type UpdateCronJobReq struct {
-	Name        string `json:"name"`
-	CronExpr    string `json:"cron_expr"`
-	Message     string `json:"message"`
-	MessageType string `json:"message_type"`
-	TargetID    int64  `json:"target_id"`
-	IsActive    bool   `json:"is_active"`
+	Name        string   `json:"name"`
+	CronExpr    string   `json:"cron_expr"`
+	Message     string   `json:"message"`
+	MessageType string   `json:"message_type"`
+	TargetID    int64    `json:"target_id"`
+	IsActive    bool     `json:"is_active"`
+	PluginIDs   []string `json:"plugin_ids"` // 触发时调用的插件目录名列表
+	Payload     string   `json:"payload"`    // JSON 字符串：传给 on_timer_call 的 payload
 }
 
 type ToggleCronJobReq struct {

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -289,6 +289,8 @@ type CronJobResp struct {
 	MessageType string     `json:"message_type"`
 	TargetID    int64      `json:"target_id"`
 	IsActive    bool       `json:"is_active"`
+	PluginIDs   []string   `json:"plugin_ids"` // 触发时调用的插件目录名列表
+	Payload     string     `json:"payload"`    // JSON 字符串：传给 on_timer_call 的 payload
 	LastRunAt   *time.Time `json:"last_run_at"`
 	LastError   string     `json:"last_error"`
 	CreatedAt   time.Time  `json:"created_at"`

--- a/internal/api/dto/transfer.go
+++ b/internal/api/dto/transfer.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"JuanNiang-Neo/internal/core/models"
 	"JuanNiang-Neo/internal/logging"
+	"encoding/json"
 )
 
 func RawProviderList2Resp(raw []models.Provider) []ProviderResp {
@@ -268,6 +269,10 @@ func RawLogEntryList2Resp(raw []logging.Entry) []LogEntryResp {
 // ---------- CronJob ----------
 
 func RawCronJob2Resp(raw *models.CronJob) CronJobResp {
+	var pluginIDs []string
+	if raw.PluginIDs != "" {
+		json.Unmarshal([]byte(raw.PluginIDs), &pluginIDs)
+	}
 	return CronJobResp{
 		ID:          raw.ID,
 		Name:        raw.Name,
@@ -276,6 +281,8 @@ func RawCronJob2Resp(raw *models.CronJob) CronJobResp {
 		MessageType: raw.MessageType,
 		TargetID:    raw.TargetID,
 		IsActive:    raw.IsActive,
+		PluginIDs:   pluginIDs,
+		Payload:     raw.Payload,
 		LastRunAt:   raw.LastRunAt,
 		LastError:   raw.LastError,
 		CreatedAt:   raw.CreatedAt,

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -72,6 +72,7 @@ func RegisterRoutes(h *server.Hertz, svc *service.Service) {
 	// Plugins
 	api.GET("/plugins", auth, svc.ListPlugins)
 	api.POST("/plugins/upload", auth, svc.UploadPlugin)
+	api.POST("/plugins/reload", auth, svc.ReloadAllPlugins)
 	api.PUT("/plugins/:id/toggle", auth, svc.TogglePlugin)
 	api.DELETE("/plugins/:id", auth, svc.DeletePlugin)
 

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -1080,6 +1080,20 @@ func (s *Service) DeletePlugin(ctx context.Context, c *app.RequestContext) {
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, nil))
 }
 
+// ReloadAllPlugins 重载所有插件（先卸载非系统插件，再全量加载）。
+func (s *Service) ReloadAllPlugins(ctx context.Context, c *app.RequestContext) {
+	if s.PluginEngine == nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: "PluginEngine 未初始化"}))
+		return
+	}
+	if err := s.PluginEngine.ReloadAll(); err != nil {
+		slog.Error("重载所有插件失败", "err", err)
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.PluginLoadFail, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, nil))
+}
+
 // ====================================================================
 // ACL
 // ====================================================================
@@ -1701,6 +1715,7 @@ func (s *Service) AddCronJob(ctx context.Context, c *app.RequestContext) {
 		data.MessageType = "private"
 	}
 
+	pluginIDsJSON, _ := json.Marshal(data.PluginIDs)
 	m := models.CronJob{
 		Name:        data.Name,
 		CronExpr:    data.CronExpr,
@@ -1708,6 +1723,8 @@ func (s *Service) AddCronJob(ctx context.Context, c *app.RequestContext) {
 		MessageType: data.MessageType,
 		TargetID:    data.TargetID,
 		IsActive:    data.IsActive,
+		PluginIDs:   string(pluginIDsJSON),
+		Payload:     data.Payload,
 	}
 	if err := s.DAO.CronJob.Create(ctx, &m); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
@@ -1745,6 +1762,9 @@ func (s *Service) UpdateCronJob(ctx context.Context, c *app.RequestContext) {
 	raw.MessageType = data.MessageType
 	raw.TargetID = data.TargetID
 	raw.IsActive = data.IsActive
+	pluginIDsJSON, _ := json.Marshal(data.PluginIDs)
+	raw.PluginIDs = string(pluginIDsJSON)
+	raw.Payload = data.Payload
 
 	if err := s.DAO.CronJob.Update(ctx, raw); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))

--- a/internal/core/models/cronjob.go
+++ b/internal/core/models/cronjob.go
@@ -6,20 +6,22 @@ import (
 	"gorm.io/gorm"
 )
 
-// CronJob 定时任务，在指定时间模拟 OneBot11 事件注入 Agent。
+// CronJob 定时任务，在指定时间模拟 OneBot11 事件注入 Agent，或触发插件 on_timer_call 回调。
 type CronJob struct {
-	ID           string      `gorm:"primaryKey;type:uuid" json:"id"`
-	Name         string      `gorm:"not null" json:"name"`
-	CronExpr     string      `gorm:"not null" json:"cron_expr"`                        // 标准 cron 表达式
-	Message      string      `gorm:"not null" json:"message"`                          // 触发时发送的消息内容
-	MessageType  string      `gorm:"default:'private'" json:"message_type"`            // private / group
-	TargetID     int64       `gorm:"not null" json:"target_id"`                        // 目标 QQ 号或群号
-	IsActive     bool        `gorm:"default:true" json:"is_active"`
-	LastRunAt    *time.Time  `json:"last_run_at,omitempty"`
-	LastError    string      `gorm:"default:''" json:"last_error"`
-	CreatedAt    time.Time   `json:"created_at"`
-	UpdatedAt    time.Time   `json:"updated_at"`
-	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
+	ID          string         `gorm:"primaryKey;type:uuid" json:"id"`
+	Name        string         `gorm:"not null" json:"name"`
+	CronExpr    string         `gorm:"not null" json:"cron_expr"`             // 标准 cron 表达式
+	Message     string         `gorm:"default:''" json:"message"`             // 触发时发送给 Agent 的消息内容（空字符串表示不发给 Agent）
+	MessageType string         `gorm:"default:'private'" json:"message_type"` // private / group
+	TargetID    int64          `gorm:"default:0" json:"target_id"`            // 目标 QQ 号或群号（仅在发给 Agent 时使用）
+	IsActive    bool           `gorm:"default:true" json:"is_active"`
+	PluginIDs   string         `gorm:"type:text;default:''" json:"plugin_ids"` // JSON 数组：触发时调用的插件目录名列表，如 ["my-plugin"]
+	Payload     string         `gorm:"type:text;default:''" json:"payload"`    // JSON 字符串：传给 on_timer_call(event) 的 payload
+	LastRunAt   *time.Time     `json:"last_run_at,omitempty"`
+	LastError   string         `gorm:"default:''" json:"last_error"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 func (CronJob) TableName() string { return "cron_jobs" }

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -329,14 +329,15 @@ func (pe *PluginEngine) ListMaps() []map[string]any {
 		loaded[name] = true
 		m := p.Manifest
 		entry := map[string]any{
-			"id":          name, // 目录名，用于 API 操作 (toggle/delete)
-			"name":        m.Name,
-			"version":     m.Version,
-			"author":      m.Author,
-			"description": m.Description,
-			"permissions": m.Permissions,
-			"is_system":   m.System,
-			"is_active":   true, // 已加载即视为 active
+			"id":             name, // 目录名，用于 API 操作 (toggle/delete)
+			"name":           m.Name,
+			"version":        m.Version,
+			"author":         m.Author,
+			"description":    m.Description,
+			"permissions":    m.Permissions,
+			"is_system":      m.System,
+			"is_active":      true, // 已加载即视为 active
+			"supports_timer": p.SupportsTimer(),
 		}
 		// 使用 Load 时的 name（目录名）查找命令，而非 manifest.Name
 		// 因为命令注册使用的 plugin 参数是 Load 的 name 参数
@@ -361,15 +362,16 @@ func (pe *PluginEngine) ListMaps() []map[string]any {
 				continue
 			}
 			out = append(out, map[string]any{
-				"id":          entry.Name(), // 目录名，用于 API 操作
-				"name":        manifest.Name,
-				"version":     manifest.Version,
-				"author":      manifest.Author,
-				"description": manifest.Description,
-				"permissions": manifest.Permissions,
-				"is_system":   manifest.System,
-				"is_active":   manifest.Enabled, // 从 YAML enabled 字段读取，兼容旧版默认 true
-				"commands":    []map[string]any{},
+				"id":             entry.Name(), // 目录名，用于 API 操作
+				"name":           manifest.Name,
+				"version":        manifest.Version,
+				"author":         manifest.Author,
+				"description":    manifest.Description,
+				"permissions":    manifest.Permissions,
+				"is_system":      manifest.System,
+				"is_active":      manifest.Enabled, // 从 YAML enabled 字段读取，兼容旧版默认 true
+				"supports_timer": false,            // 未加载的插件无法检测，默认 false
+				"commands":       []map[string]any{},
 			})
 		}
 	}
@@ -387,6 +389,7 @@ type EventData struct {
 	RawMessage  string         `json:"raw_message"`
 	Admins      []string       `json:"admins"`
 	Webhook     map[string]any `json:"webhook,omitempty"`
+	Payload     map[string]any `json:"payload,omitempty"` // on_timer_call 携带的 payload
 }
 
 // HasPluginCommand 检查消息是否匹配已注册的插件命令（不执行，仅供策略层判断）。
@@ -485,6 +488,64 @@ func (pe *PluginEngine) OnWebhook(event EventData) (consumed bool) {
 		}
 	}
 	return false
+}
+
+// OnTimerCall 定时任务触发插件 on_timer_call 回调。
+// pluginIDs 指定要调用的插件（目录名列表），payload 为 CronJob 配置的 JSON payload，
+// admins 为系统管理员 QQ 列表。
+// 实现 cronjob.PluginTimerDispatcher 接口。
+func (pe *PluginEngine) OnTimerCall(pluginIDs []string, payload map[string]any, admins []string) {
+	pe.mu.RLock()
+	defer pe.mu.RUnlock()
+
+	event := EventData{
+		PostType: "timer",
+		Admins:   admins,
+		Payload:  payload,
+	}
+
+	for _, name := range pluginIDs {
+		p, ok := pe.plugins[name]
+		if !ok {
+			slog.Warn("OnTimerCall: 插件未加载", "plugin", name)
+			continue
+		}
+		fn := p.State.GetGlobal("on_timer_call")
+		if fn.Type() != lua.LTFunction {
+			slog.Warn("OnTimerCall: 插件未定义 on_timer_call", "plugin", name)
+			continue
+		}
+		table := eventToLuaTable(p.State, event)
+		p.State.Push(fn)
+		p.State.Push(table)
+		if err := p.State.PCall(1, 0, nil); err != nil {
+			slog.Error("插件 on_timer_call 错误", "plugin", name, "err", err)
+		}
+	}
+}
+
+// SupportsTimer 检查插件是否支持定时任务回调（定义了 on_timer_call 全局函数）。
+func (p *LoadedPlugin) SupportsTimer() bool {
+	fn := p.State.GetGlobal("on_timer_call")
+	return fn.Type() == lua.LTFunction
+}
+
+// ReloadAll 卸载所有非系统插件后重新加载全部插件。
+func (pe *PluginEngine) ReloadAll() error {
+	pe.mu.Lock()
+	// 先卸载非系统插件
+	for name, p := range pe.plugins {
+		if p.Manifest.System {
+			continue
+		}
+		pe.commands.UnregisterPlugin(name)
+		p.State.Close()
+		delete(pe.plugins, name)
+	}
+	pe.mu.Unlock()
+
+	// LoadAll 在内部会重新取锁并加载所有插件
+	return pe.LoadAll()
 }
 
 func (p *LoadedPlugin) HasPermission(perm string) bool {
@@ -1466,6 +1527,9 @@ func eventToLuaTable(L *lua.LState, ev EventData) *lua.LTable {
 	}
 	if len(ev.Webhook) > 0 {
 		L.SetField(t, "webhook", goToLuaValue(L, ev.Webhook))
+	}
+	if len(ev.Payload) > 0 {
+		L.SetField(t, "payload", goToLuaValue(L, ev.Payload))
 	}
 	return t
 }

--- a/internal/pluggin/sdk/jn.lua
+++ b/internal/pluggin/sdk/jn.lua
@@ -19,14 +19,15 @@ local M = {}
 -- 事件类型
 -- ====================================================================
 
----@class jn.Event OneBot11 消息事件
----@field post_type string 事件类型 ("message")
+---@class jn.Event OneBot11 消息/定时/webhook 事件
+---@field post_type string 事件类型 ("message" | "timer" | "webhook")
 ---@field message_type string "private" | "group"
 ---@field user_id number 发送者 QQ 号
 ---@field group_id number 群号 (private 时为 0)
 ---@field raw_message string 原始消息文本
 ---@field admins string[] 系统管理员 QQ 号列表
 ---@field webhook table? webhook 事件专属字段
+---@field payload table? on_timer_call 携带的 CronJob payload
 
 -- ====================================================================
 -- log 日志

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,11 +8,14 @@
       "name": "juanniang-neo-dashboard",
       "version": "1.0.0",
       "dependencies": {
+        "@codemirror/lang-json": "^6.0.2",
         "@mdi/font": "^7.4.47",
         "axios": "^1.6.0",
+        "codemirror": "^6.0.2",
         "date-fns": "^2.30.0",
         "pinia": "^2.1.6",
         "vue": "^3.3.4",
+        "vue-codemirror": "^6.1.1",
         "vue-router": "^4.2.4",
         "vuetify": "^3.7.0"
       },
@@ -79,6 +82,97 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmmirror.com/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmmirror.com/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmmirror.com/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmmirror.com/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmmirror.com/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.7",
+      "resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.43.7.tgz",
+      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -501,6 +595,47 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmmirror.com/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmmirror.com/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@mdi/font": {
@@ -1484,6 +1619,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1495,6 +1645,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2165,6 +2321,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2337,6 +2499,22 @@
         }
       }
     },
+    "node_modules/vue-codemirror": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmmirror.com/vue-codemirror/-/vue-codemirror-6.1.1.tgz",
+      "integrity": "sha512-rTAYo44owd282yVxKtJtnOi7ERAcXTeviwoPXjIc6K/IQYUsoDkzPvw/JDFtSP6T7Cz/2g3EHaEyeyaQCKoDMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/commands": "6.x",
+        "@codemirror/language": "6.x",
+        "@codemirror/state": "6.x",
+        "@codemirror/view": "6.x"
+      },
+      "peerDependencies": {
+        "codemirror": "6.x",
+        "vue": "3.x"
+      }
+    },
     "node_modules/vue-demi": {
       "version": "0.14.10",
       "resolved": "https://registry.npmmirror.com/vue-demi/-/vue-demi-0.14.10.tgz",
@@ -2421,6 +2599,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -12,11 +12,14 @@
     "lint": "eslint . --ext .vue,.js,.ts --fix"
   },
   "dependencies": {
+    "@codemirror/lang-json": "^6.0.2",
     "@mdi/font": "^7.4.47",
     "axios": "^1.6.0",
+    "codemirror": "^6.0.2",
     "date-fns": "^2.30.0",
     "pinia": "^2.1.6",
     "vue": "^3.3.4",
+    "vue-codemirror": "^6.1.1",
     "vue-router": "^4.2.4",
     "vuetify": "^3.7.0"
   },

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -128,6 +128,7 @@ export const toolApi = {
 export const pluginApi = {
   list: () => client.get('/plugins'),
   upload: (file: File) => { const fd = new FormData(); fd.append('file', file); return client.post('/plugins/upload', fd, { headers: { 'Content-Type': 'multipart/form-data' } }) },
+  reloadAll: () => client.post('/plugins/reload'),
   toggle: (id: string, is_active: boolean) => client.put(`/plugins/${id}/toggle`, { is_active }),
   delete: (id: string) => client.delete(`/plugins/${id}`),
 }
@@ -202,12 +203,15 @@ export const backgroundTaskApi = {
 // ======== CronJob ========
 export interface CronJobResp {
   id: string; name: string; cron_expr: string; message: string; message_type: string
-  target_id: number; is_active: boolean; last_run_at?: string; last_error: string
+  target_id: number; is_active: boolean
+  plugin_ids: string[]; payload: string
+  last_run_at?: string; last_error: string
   created_at: string; updated_at: string
 }
 export interface AddCronJobReq {
   name: string; cron_expr: string; message: string; message_type: string
   target_id: number; is_active: boolean
+  plugin_ids: string[]; payload: string
 }
 
 export const cronJobApi = {

--- a/web/src/views/CronJobsPage.vue
+++ b/web/src/views/CronJobsPage.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="page-header">
       <div class="page-title">CronJob 定时任务</div>
-      <div class="page-subtitle">在指定时间模拟 OneBot11 事件注入 Agent，或触发插件 on_timer_call 回调</div>
+      <div class="page-subtitle">在指定时间触发 Agent 消息或调用插件 on_timer_call 回调</div>
     </div>
     <div class="d-flex justify-end mb-4">
       <v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增任务</v-btn>
@@ -12,16 +12,16 @@
         <v-switch :model-value="item.is_active" color="primary" density="compact" hide-details
           @update:model-value="(v: any) => toggle(item.id, !!v)" />
       </template>
-      <template #item.message_type="{ item }">
-        <v-chip :color="item.message_type === 'group' ? 'info' : 'warning'" size="small" variant="tonal">
-          {{ item.message_type === 'group' ? '群聊' : '私聊' }}
-        </v-chip>
+      <template #item.dispatch_type="{ item }">
+        <v-chip v-if="item.plugin_ids && item.plugin_ids.length > 0" size="small" color="success" variant="tonal">Plugin</v-chip>
+        <v-chip v-if="item.message" size="small" color="info" variant="tonal" class="ml-1">Agent</v-chip>
+        <span v-if="!item.message && (!item.plugin_ids || item.plugin_ids.length === 0)" class="text-disabled">未配置</span>
       </template>
       <template #item.plugin_ids="{ item }">
         <div class="d-flex flex-wrap" style="gap:4px" v-if="item.plugin_ids && item.plugin_ids.length > 0">
           <v-chip v-for="pid in item.plugin_ids" :key="pid" size="x-small" variant="tonal" color="success">{{ pid }}</v-chip>
         </div>
-        <span v-else class="text-disabled">仅 Agent</span>
+        <span v-else class="text-disabled">-</span>
       </template>
       <template #item.last_run_at="{ item }">
         <span v-if="item.last_run_at">{{ new Date(item.last_run_at).toLocaleString() }}</span>
@@ -46,35 +46,54 @@
             <v-text-field v-model="form.name" label="任务名称" class="mb-3" />
             <v-text-field v-model="form.cron_expr" label="Cron 表达式" class="mb-3"
               hint="秒 分 时 日 月 周。例如: 0 0 8 * * * 表示每天8点" persistent-hint />
+            <v-switch v-model="form.is_active" label="启用" color="primary" class="mb-3" />
 
             <v-divider class="mb-3" />
 
-            <div class="text-subtitle-2 mb-2">Agent 分发（可选）</div>
-            <v-select v-model="form.message_type" :items="msgTypeOptions" label="消息类型" class="mb-3" />
-            <v-text-field v-model.number="form.target_id" label="目标 ID (QQ号/群号)" type="number" class="mb-3" />
-            <v-textarea v-model="form.message" label="消息内容" class="mb-3" rows="2"
-              hint="给 Agent 的用户消息。留空则不发给 Agent。" />
+            <!-- Tab: Agent / Plugin -->
+            <v-tabs v-model="tab" color="primary" class="mb-4">
+              <v-tab value="agent">Agent 分发</v-tab>
+              <v-tab value="plugin">Plugin 分发</v-tab>
+            </v-tabs>
 
-            <v-divider class="mb-3" />
+            <v-window v-model="tab">
+              <!-- Agent 分发表单 -->
+              <v-window-item value="agent">
+                <v-select v-model="form.message_type" :items="msgTypeOptions" label="消息类型" class="mb-3" />
+                <v-text-field v-model.number="form.target_id" label="目标 ID (QQ号/群号)" type="number" class="mb-3" />
+                <v-textarea v-model="form.message" label="消息内容" class="mb-3" rows="3"
+                  hint="给 Agent 的用户消息。留空则不发给 Agent。" />
+              </v-window-item>
 
-            <div class="text-subtitle-2 mb-2">Plugin 分发（可选）</div>
-            <v-select
-              v-model="form.plugin_ids"
-              :items="timerPlugins"
-              item-title="name"
-              item-value="id"
-              label="触发插件"
-              multiple
-              chips
-              closable-chips
-              class="mb-3"
-              hint="仅显示支持 on_timer_call 且已启用的插件"
-              persistent-hint
-            />
-            <v-textarea v-model="form.payload" label="Payload (JSON)" class="mb-3" rows="3"
-              hint="传给 on_timer_call(event) 的 JSON 字符串。留空则传空对象。" />
-
-            <v-switch v-model="form.is_active" label="启用" color="primary" />
+              <!-- Plugin 分发表单 -->
+              <v-window-item value="plugin">
+                <v-select
+                  v-model="form.plugin_ids"
+                  :items="timerPlugins"
+                  item-title="name"
+                  item-value="id"
+                  label="触发插件"
+                  multiple
+                  chips
+                  closable-chips
+                  class="mb-3"
+                  hint="仅显示支持 on_timer_call 且已启用的插件"
+                  persistent-hint
+                />
+                <div class="text-caption text-medium-emphasis mb-1">Payload (JSON)</div>
+                <div class="editor-wrapper mb-3">
+                  <Codemirror
+                    v-model="form.payload"
+                    :extensions="cmExtensions"
+                    :style="{ height: '200px' }"
+                    :indent-with-tab="true"
+                    :tab-size="2"
+                    placeholder='{"target_qq": 123456, "message": "定时提醒"}'
+                  />
+                </div>
+                <div v-if="payloadError" class="text-error text-caption mb-2">{{ payloadError }}</div>
+              </v-window-item>
+            </v-window>
           </v-form>
         </v-card-text>
         <v-card-actions>
@@ -101,6 +120,9 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { Codemirror } from 'vue-codemirror'
+import { json } from '@codemirror/lang-json'
+import { basicSetup } from 'codemirror'
 import { cronJobApi, type CronJobResp, type AddCronJobReq } from '@/api'
 import { pluginApi } from '@/api'
 import { useToastStore } from '@/stores/toast'
@@ -111,6 +133,7 @@ const items = ref<CronJobResp[]>([])
 const dialog = ref(false); const deleteDialog = ref(false)
 const editing = ref<string | null>(null); const saving = ref(false); const deleting = ref(false)
 const deleteTarget = ref<CronJobResp | null>(null); const formRef = ref()
+const tab = ref('agent')
 
 const msgTypeOptions = [
   { title: '私聊', value: 'private' },
@@ -120,8 +143,7 @@ const msgTypeOptions = [
 const headers = [
   { title: '名称', key: 'name' },
   { title: 'Cron 表达式', key: 'cron_expr' },
-  { title: '消息类型', key: 'message_type' },
-  { title: '目标 ID', key: 'target_id' },
+  { title: '分发类型', key: 'dispatch_type' },
   { title: '触发插件', key: 'plugin_ids' },
   { title: '上次执行', key: 'last_run_at' },
   { title: '上次错误', key: 'last_error' },
@@ -135,6 +157,17 @@ const defaultForm = (): AddCronJobReq => ({
 })
 
 const form = ref<AddCronJobReq>(defaultForm())
+
+// CodeMirror 配置
+const cmExtensions = [basicSetup, json()]
+
+// JSON payload 实时校验
+const payloadError = computed(() => {
+  const v = form.value.payload?.trim()
+  if (!v) return ''
+  try { JSON.parse(v); return '' }
+  catch (e: any) { return `JSON 格式错误: ${e.message}` }
+})
 
 // 获取支持 on_timer_call 且启用的插件列表
 const timerPlugins = ref<Array<{ id: string; name: string }>>([])
@@ -154,7 +187,10 @@ async function fetch() {
   catch { toastStore.error('获取失败') }
   finally { loading.value = false }
 }
-function openAdd() { editing.value = null; form.value = defaultForm(); loadTimerPlugins(); dialog.value = true }
+function openAdd() {
+  editing.value = null; form.value = defaultForm(); tab.value = 'agent'
+  loadTimerPlugins(); dialog.value = true
+}
 function openEdit(item: CronJobResp) {
   editing.value = item.id
   form.value = {
@@ -162,6 +198,8 @@ function openEdit(item: CronJobResp) {
     message_type: item.message_type, target_id: item.target_id, is_active: item.is_active,
     plugin_ids: item.plugin_ids || [], payload: item.payload || '',
   }
+  // 根据已有数据决定默认 tab
+  tab.value = (item.plugin_ids && item.plugin_ids.length > 0) ? 'plugin' : 'agent'
   loadTimerPlugins()
   dialog.value = true
 }
@@ -190,3 +228,17 @@ async function handleDelete() {
 }
 onMounted(fetch)
 </script>
+
+<style scoped>
+.editor-wrapper {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.editor-wrapper :deep(.cm-editor) {
+  outline: none !important;
+}
+.editor-wrapper :deep(.cm-focused) {
+  outline: none !important;
+}
+</style>

--- a/web/src/views/CronJobsPage.vue
+++ b/web/src/views/CronJobsPage.vue
@@ -241,4 +241,13 @@ onMounted(fetch)
 .editor-wrapper :deep(.cm-focused) {
   outline: none !important;
 }
+.editor-wrapper :deep(.cm-gutters) {
+  background: #000 !important;
+  color: #888 !important;
+  border-right: 1px solid #333 !important;
+}
+.editor-wrapper :deep(.cm-activeLineGutter) {
+  background: #1a1a1a !important;
+  color: #ccc !important;
+}
 </style>

--- a/web/src/views/CronJobsPage.vue
+++ b/web/src/views/CronJobsPage.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="page-header">
       <div class="page-title">CronJob 定时任务</div>
-      <div class="page-subtitle">在指定时间模拟 OneBot11 事件，注入 Agent 自动处理</div>
+      <div class="page-subtitle">在指定时间模拟 OneBot11 事件注入 Agent，或触发插件 on_timer_call 回调</div>
     </div>
     <div class="d-flex justify-end mb-4">
       <v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增任务</v-btn>
@@ -16,6 +16,12 @@
         <v-chip :color="item.message_type === 'group' ? 'info' : 'warning'" size="small" variant="tonal">
           {{ item.message_type === 'group' ? '群聊' : '私聊' }}
         </v-chip>
+      </template>
+      <template #item.plugin_ids="{ item }">
+        <div class="d-flex flex-wrap" style="gap:4px" v-if="item.plugin_ids && item.plugin_ids.length > 0">
+          <v-chip v-for="pid in item.plugin_ids" :key="pid" size="x-small" variant="tonal" color="success">{{ pid }}</v-chip>
+        </div>
+        <span v-else class="text-disabled">仅 Agent</span>
       </template>
       <template #item.last_run_at="{ item }">
         <span v-if="item.last_run_at">{{ new Date(item.last_run_at).toLocaleString() }}</span>
@@ -32,7 +38,7 @@
     </v-data-table>
 
     <!-- 新增/编辑弹窗 -->
-    <v-dialog v-model="dialog" max-width="640">
+    <v-dialog v-model="dialog" max-width="700">
       <v-card rounded="lg">
         <v-card-title>{{ editing ? '编辑 CronJob' : '新增 CronJob' }}</v-card-title>
         <v-card-text>
@@ -40,10 +46,34 @@
             <v-text-field v-model="form.name" label="任务名称" class="mb-3" />
             <v-text-field v-model="form.cron_expr" label="Cron 表达式" class="mb-3"
               hint="秒 分 时 日 月 周。例如: 0 0 8 * * * 表示每天8点" persistent-hint />
+
+            <v-divider class="mb-3" />
+
+            <div class="text-subtitle-2 mb-2">Agent 分发（可选）</div>
             <v-select v-model="form.message_type" :items="msgTypeOptions" label="消息类型" class="mb-3" />
             <v-text-field v-model.number="form.target_id" label="目标 ID (QQ号/群号)" type="number" class="mb-3" />
-            <v-textarea v-model="form.message" label="消息内容" class="mb-3" rows="3"
-              hint="该文本将作为用户消息发送给 Agent，Agent 会据此生成回复。不会发送 Markdown 格式。" />
+            <v-textarea v-model="form.message" label="消息内容" class="mb-3" rows="2"
+              hint="给 Agent 的用户消息。留空则不发给 Agent。" />
+
+            <v-divider class="mb-3" />
+
+            <div class="text-subtitle-2 mb-2">Plugin 分发（可选）</div>
+            <v-select
+              v-model="form.plugin_ids"
+              :items="timerPlugins"
+              item-title="name"
+              item-value="id"
+              label="触发插件"
+              multiple
+              chips
+              closable-chips
+              class="mb-3"
+              hint="仅显示支持 on_timer_call 且已启用的插件"
+              persistent-hint
+            />
+            <v-textarea v-model="form.payload" label="Payload (JSON)" class="mb-3" rows="3"
+              hint="传给 on_timer_call(event) 的 JSON 字符串。留空则传空对象。" />
+
             <v-switch v-model="form.is_active" label="启用" color="primary" />
           </v-form>
         </v-card-text>
@@ -70,8 +100,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { cronJobApi, type CronJobResp, type AddCronJobReq } from '@/api'
+import { pluginApi } from '@/api'
 import { useToastStore } from '@/stores/toast'
 
 const toastStore = useToastStore()
@@ -91,6 +122,7 @@ const headers = [
   { title: 'Cron 表达式', key: 'cron_expr' },
   { title: '消息类型', key: 'message_type' },
   { title: '目标 ID', key: 'target_id' },
+  { title: '触发插件', key: 'plugin_ids' },
   { title: '上次执行', key: 'last_run_at' },
   { title: '上次错误', key: 'last_error' },
   { title: '启用', key: 'is_active', align: 'center' as const },
@@ -99,9 +131,22 @@ const headers = [
 
 const defaultForm = (): AddCronJobReq => ({
   name: '', cron_expr: '', message: '', message_type: 'private', target_id: 0, is_active: true,
+  plugin_ids: [], payload: '',
 })
 
 const form = ref<AddCronJobReq>(defaultForm())
+
+// 获取支持 on_timer_call 且启用的插件列表
+const timerPlugins = ref<Array<{ id: string; name: string }>>([])
+async function loadTimerPlugins() {
+  try {
+    const res = await pluginApi.list()
+    const plugins = (res.data.data || []) as any[]
+    timerPlugins.value = plugins
+      .filter((p: any) => p.supports_timer && p.is_active)
+      .map((p: any) => ({ id: p.id || p.name, name: `${p.name} (v${p.version})` }))
+  } catch { /* ignore */ }
+}
 
 async function fetch() {
   loading.value = true
@@ -109,13 +154,15 @@ async function fetch() {
   catch { toastStore.error('获取失败') }
   finally { loading.value = false }
 }
-function openAdd() { editing.value = null; form.value = defaultForm(); dialog.value = true }
+function openAdd() { editing.value = null; form.value = defaultForm(); loadTimerPlugins(); dialog.value = true }
 function openEdit(item: CronJobResp) {
   editing.value = item.id
   form.value = {
     name: item.name, cron_expr: item.cron_expr, message: item.message,
     message_type: item.message_type, target_id: item.target_id, is_active: item.is_active,
+    plugin_ids: item.plugin_ids || [], payload: item.payload || '',
   }
+  loadTimerPlugins()
   dialog.value = true
 }
 async function toggle(id: string, v: boolean) {

--- a/web/src/views/PluginsPage.vue
+++ b/web/src/views/PluginsPage.vue
@@ -5,6 +5,7 @@
       <div class="page-subtitle">管理 Lua 插件，支持 ZIP 上传</div>
     </div>
     <div class="d-flex justify-end mb-4" style="gap:12px">
+      <v-btn color="warning" variant="tonal" prepend-icon="mdi-refresh" @click="handleReloadAll" :loading="reloading">重载全部</v-btn>
       <v-btn color="primary" variant="tonal" prepend-icon="mdi-upload" @click="triggerUpload">上传 ZIP</v-btn>
       <input ref="fileInput" type="file" accept=".zip" style="display:none" @change="handleFile" />
     </div>
@@ -18,6 +19,10 @@
           <v-chip v-for="p in (item.permissions || [])" :key="p" size="x-small" variant="tonal" color="info">{{ p }}</v-chip>
           <span v-if="!item.permissions || item.permissions.length === 0" class="text-caption text-medium-emphasis">(无)</span>
         </div>
+      </template>
+      <template #item.supports_timer="{ item }">
+        <v-chip v-if="item.supports_timer" size="small" color="success" variant="tonal">支持</v-chip>
+        <v-chip v-else size="small" color="grey" variant="tonal">不支持</v-chip>
       </template>
       <template #item.is_active="{ item }">
         <v-switch
@@ -119,11 +124,13 @@ interface PluginItem {
   permissions?: string[]
   is_system?: boolean
   is_active?: boolean
+  supports_timer?: boolean
   commands?: Array<{ path: string[]; description: string; usage: string; is_leaf: boolean }>
 }
 
 const toastStore = useToastStore()
 const loading = ref(true)
+const reloading = ref(false)
 const items = ref<PluginItem[]>([])
 const fileInput = ref<HTMLInputElement | null>(null)
 const deleteDialog = ref(false)
@@ -136,6 +143,7 @@ const headers = [
   { title: '名称', key: 'name' },
   { title: '版本', key: 'version' },
   { title: '权限', key: 'permissions' },
+  { title: '定时支持', key: 'supports_timer', align: 'center' as const },
   { title: '类型', key: 'is_system' },
   { title: 'Active', key: 'is_active', align: 'center' as const },
   { title: '操作', key: 'actions', align: 'center' as const, sortable: false },
@@ -162,6 +170,13 @@ async function handleFile(e: Event) {
   if (!f) return
   try { await pluginApi.upload(f); toastStore.success('上传成功'); await fetch() }
   catch (err: any) { toastStore.error(err?.message || '上传失败') }
+}
+
+async function handleReloadAll() {
+  reloading.value = true
+  try { await pluginApi.reloadAll(); toastStore.success('已重载全部插件'); await fetch() }
+  catch (e: any) { toastStore.error(e?.response?.data?.info || '重载失败') }
+  finally { reloading.value = false }
 }
 
 async function toggle(id: string, v: boolean) {


### PR DESCRIPTION
### 新增功能

- **CronJob Plugin 分发**：定时任务可触发指定插件的 `on_timer_call(event)` 回调，支持 JSON Payload，与 Agent 分发独立并存
- **插件检测**：运行时检查 `on_timer_call` 全局函数 → `supports_timer` 字段，前端多选下拉框自动过滤可选插件
- **CodeMirror JSON 编辑器**：Payload 输入框替换为带语法高亮、实时校验的代码编辑器
- **插件热重载**：`POST /plugins/reload` + 前端按钮，无需重启即可重载全部非系统插件
- **Agent / Plugin Tab 分离**：CronJob 表单用 Tab 页分开两种分发模式，互不干扰
- **示例插件** `cron-example`：向 Payload 指定 QQ/群发送定时消息
