### PR TITLE
fix: Docker 容器内嵌插件无法写入磁盘（bind mount 权限）

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ networks:
     driver: bridge
 ```
 
-同目录放 `.env`（按需修改），然后：
+同目录放 `.env`（按需修改）。**首次启动前**需创建插件目录并赋权：
 
 ```bash
+mkdir -p data/pluggins && chmod 777 data/pluggins
 docker compose up -d
 # 仪表板  http://localhost:8090   初始账号 admin / Admin123（首次启动务必改密码）
 # OneBot11 反向 WS  ws://localhost:8081/   带头 Authorization: Bearer <OB_TOKEN>

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -79,6 +79,10 @@ services:
     volumes:
       # Lua 插件目录 (convention: data/pluggins/<name>/{main.lua,pluggin.yaml})
       # 容器内二进制 CWD=/app, 硬编码加载 "data/pluggins" -> /app/data/pluggins。
+      #
+      # ⚠️ 首次启动前必须先在宿主机创建此目录并赋予写权限，否则容器内非 root 用户
+      # 无法写入内嵌的 SDK 与 system 插件：
+      #   mkdir -p data/pluggins && chmod 777 data/pluggins
       - ../data/pluggins:/app/data/pluggins
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8090/health"]

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -1616,6 +1616,12 @@ var systemPluginMain string
 // ensureEmbeddedAssets 在启动时把内嵌的 SDK 与 system 插件落盘到 data/pluggins/。
 // SDK 与 system 插件始终覆盖写入，确保 Docker 挂载卷中的版本与二进制一致。
 func (pe *PluginEngine) ensureEmbeddedAssets() {
+	// 0. 确保 basePath 存在且可写
+	if err := os.MkdirAll(pe.basePath, 0o755); err != nil {
+		slog.Error("无法创建插件根目录，内嵌资源写入跳过", "basePath", pe.basePath, "err", err)
+		return
+	}
+
 	// 1. SDK 总是覆盖
 	sdkDir := filepath.Join(pe.basePath, "sdk")
 	if err := os.MkdirAll(sdkDir, 0o755); err != nil {
@@ -1623,7 +1629,9 @@ func (pe *PluginEngine) ensureEmbeddedAssets() {
 	} else {
 		sdkFile := filepath.Join(sdkDir, "jn.lua")
 		if err := os.WriteFile(sdkFile, []byte(jnSDKSource), 0o644); err != nil {
-			slog.Warn("写入 SDK 文件失败", "err", err)
+			slog.Warn("写入 SDK 文件失败", "path", sdkFile, "err", err)
+		} else {
+			slog.Info("SDK 已同步到磁盘", "path", sdkFile)
 		}
 	}
 


### PR DESCRIPTION
### 问题
使用 docker compose 启动后 `data/pluggins/` 为空，SDK 和 system 插件未落盘。
根因：bind mount `./data/pluggins` 在宿主机目录不存在时 Docker 以 root 创建，
容器以非 root 用户运行导致写入被拒，而 `ensureEmbeddedAssets` 的失败只打 Warn 静默跳过。

### 修复
- `ensureEmbeddedAssets`：显式 `MkdirAll(basePath)` + Error 日志，写入成功打 Info
- `docker-compose.yaml`：volume 注释加首次启动 `chmod 777` 提示
- `README.md`：快速部署命令前加 `mkdir -p data/pluggins && chmod 777`
