### PR TITLE
🎨 前端视觉重构 + 核心规则重构

### DIFF
--- a/data/pluggins/cron-example/main.lua
+++ b/data/pluggins/cron-example/main.lua
@@ -22,7 +22,7 @@ local jn = require("jn")
 
 -- 定时任务回调
 ---@param event jn.Event
-function on_timer_call(event)
+function on_cronjob(event)
     local payload = event.payload or {}
     local target_qq = payload.target_qq
     local message = payload.message

--- a/internal/adapter/models.go
+++ b/internal/adapter/models.go
@@ -24,6 +24,11 @@ type Event struct {
 	// IsCronJob 标记此事件是定时任务触发的。
 	IsCronJob bool `json:"-"`
 
+	// CronJobPayload 定时任务携带的 JSON payload（透传给插件 on_cronjob）。
+	CronJobPayload string `json:"-"`
+	// CronJobPluginIDs 定时任务指定要通知的插件目录名（空 = 通知所有插件）。
+	CronJobPluginIDs []string `json:"-"`
+
 	// SkipReplyCheck 标记跳过回复策略检查（由 Plugin skip_reply_check 设置）。
 	SkipReplyCheck bool `json:"-"`
 

--- a/internal/agent/cronjob/manager.go
+++ b/internal/agent/cronjob/manager.go
@@ -2,6 +2,8 @@ package cronjob
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -104,9 +106,11 @@ func (m *Manager) makeJobFunc(job *models.CronJob) func() {
 
 		// 构造 cronjob 事件，发送给 Agent 事件循环（经 PluginEngine.Dispatch 分发给插件）
 		ev := adapter.Event{
-			PostType:  "cronjob",
-			IsCronJob: true,
-			Time:      time.Now().Unix(),
+			PostType:         "cronjob",
+			IsCronJob:        true,
+			Time:             time.Now().Unix(),
+			CronJobPayload:   job.Payload,
+			CronJobPluginIDs: parsePluginIDs(job.PluginIDs),
 		}
 
 		if job.Message != "" {
@@ -130,4 +134,16 @@ func (m *Manager) makeJobFunc(job *models.CronJob) func() {
 			log.Warn("CronJob: 事件通道已满，丢弃事件", "name", job.Name)
 		}
 	}
+}
+
+// parsePluginIDs 将 JSON 数组字符串解析为插件目录名列表（空/非法返回 nil）。
+func parsePluginIDs(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(s), &ids); err != nil {
+		return nil
+	}
+	return ids
 }

--- a/internal/agent/eino_middleware.go
+++ b/internal/agent/eino_middleware.go
@@ -25,8 +25,9 @@ type JuanNiangMiddleware struct {
 	admins     []string
 }
 
-// BeforeAgent 在 Agent 运行前注入动态 Instruction 和按需清空工具列表（AgentLite）。
+// BeforeAgent 在 Agent 运行前注入动态 Instruction 和按需过滤工具列表（AgentLite）。
 // DynamicInstruction 和 AgentLite 从 context 中读取（由 handleMessage 注入）。
+// AgentLite 与正常模式一致（保留 ReAct 循环），仅过滤掉 MCP、沙箱与文生图工具。
 func (m *JuanNiangMiddleware) BeforeAgent(
 	ctx context.Context,
 	runCtx *adk.ChatModelAgentContext,
@@ -37,10 +38,42 @@ func (m *JuanNiangMiddleware) BeforeAgent(
 			runCtx.Instruction = sc.DynamicInstruction
 		}
 		if sc.AgentLite {
-			runCtx.Tools = nil
+			runCtx.Tools = filterAgentLiteTools(ctx, m.h, runCtx.Tools)
 		}
 	}
 	return ctx, runCtx, nil
+}
+
+// agentLiteDisabledToolNames 是 AgentLite 模式下禁用的内置工具名
+// （沙箱相关 + 文生图）。MCP 工具通过 HagoCenter.MCP.HasTool 判定，全部禁用。
+var agentLiteDisabledToolNames = map[string]bool{
+	"create_sandbox": true,
+	"list_sandboxes": true,
+	"browser_search": true,
+	"command_exec":   true,
+	"code_exec":      true,
+	"text_to_image":  true,
+}
+
+// filterAgentLiteTools 过滤 AgentLite 模式下不允许使用的工具：
+// 保留 ReAct 循环与其余工具，仅禁用所有 MCP 工具、沙箱工具与文生图工具。
+func filterAgentLiteTools(ctx context.Context, h *HagoCenter, tools []einotool.BaseTool) []einotool.BaseTool {
+	kept := make([]einotool.BaseTool, 0, len(tools))
+	for _, t := range tools {
+		info, err := t.Info(ctx)
+		if err != nil || info == nil {
+			kept = append(kept, t) // 无法获取元数据时保守保留
+			continue
+		}
+		if agentLiteDisabledToolNames[info.Name] {
+			continue
+		}
+		if h.MCP != nil && h.MCP.HasTool(ctx, info.Name) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	return kept
 }
 
 // MsgSessionCtx 携带单条消息的 per-goroutine 状态。

--- a/internal/agent/eino_middleware.go
+++ b/internal/agent/eino_middleware.go
@@ -11,18 +11,16 @@ import (
 )
 
 // JuanNiangMiddleware 是 Eino ChatModelAgent 的自定义中间件，
-// 实现 ACL 权限检查和工具调用日志。
+// 实现动态指令注入、AgentLite 工具过滤和工具调用日志。
 // DynamicInstruction 和 AgentLite 通过 context (MsgSessionCtx) 传递，
 // 在 BeforeAgent 钩子中读取。
+// 注：ACL 现仅管理聊天黑名单（在 handleMessage 阶段过滤消息），
+// 不再对工具调用做 ACL 检查。
 type JuanNiangMiddleware struct {
 	*adk.BaseChatModelAgentMiddleware
 
-	h          *HagoCenter
-	msg        *adapter.MessageEvent
-	userID     int64
-	chatAreaID string
-	isAdmin    bool
-	admins     []string
+	h   *HagoCenter
+	msg *adapter.MessageEvent
 }
 
 // BeforeAgent 在 Agent 运行前注入动态 Instruction 和按需过滤工具列表（AgentLite）。
@@ -103,9 +101,9 @@ func GetMsgSessionCtx(ctx context.Context) *MsgSessionCtx {
 }
 
 // WrapInvokableToolCall 包装每个工具的同步调用：
-//   - Admin 用户绕过 ACL
-//   - 非 Admin 进行 ACL 检查（内置工具走 CheckTool，MCP 工具走 CheckMCP）
+//   - 更新活跃循环的当前工具（供 Web 监控页展示）
 //   - 所有工具前台同步执行并记录日志
+// 注：ACL 只管理聊天黑名单，工具调用不再受 ACL 限制。
 func (m *JuanNiangMiddleware) WrapInvokableToolCall(
 	ctx context.Context,
 	endpoint adk.InvokableToolCallEndpoint,
@@ -119,22 +117,6 @@ func (m *JuanNiangMiddleware) WrapInvokableToolCall(
 		// 更新活跃循环的当前工具（供 Web 监控页展示）
 		if sc := GetMsgSessionCtx(ctx); sc != nil && m.h.Loops != nil {
 			m.h.Loops.UpdateTool(sc.LoopID, toolName)
-		}
-
-		// --- ACL 检查 ---
-		if !m.isAdmin {
-			isMCP := m.h.MCP != nil && m.h.MCP.HasTool(ctx, toolName)
-			var allowed bool
-			var denial string
-			if isMCP {
-				allowed, denial = m.h.ACL.CheckMCP(ctx, m.userID, m.chatAreaID, toolName)
-			} else {
-				allowed, denial = m.h.ACL.CheckTool(ctx, m.userID, m.chatAreaID, toolName)
-			}
-			if !allowed {
-				log.Info("ACL 拒绝工具调用", "user_id", m.userID, "tool", toolName, "reason", denial)
-				return denial, nil
-			}
 		}
 
 		// --- 直接执行（所有工具前台同步执行）---

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -29,6 +29,8 @@ type ReplySettings struct {
 	AgentLite          bool
 	BotName            string
 	RelevanceThreshold float64
+	RelevancePrompt    string // 相关性检测自定义提示词（空则用默认）
+	RelevanceModel     string // 相关性检测使用的 Text Provider ID（空则用默认）
 }
 
 // runEventLoop 是主事件循环，监听 OneBot11 事件并调用 Agent 处理。
@@ -151,6 +153,8 @@ func (h *HagoCenter) getReplySettings(ctx context.Context) ReplySettings {
 		AgentLite:          cfg.AgentLite,
 		BotName:            cfg.BotName,
 		RelevanceThreshold: cfg.RelevanceThreshold,
+		RelevancePrompt:    cfg.RelevancePrompt,
+		RelevanceModel:     cfg.RelevanceModel,
 	}
 }
 
@@ -181,7 +185,7 @@ func (h *HagoCenter) checkReplyStrategy(ctx context.Context, ev adapter.Event, r
 			chatAreaID = area.ID
 		}
 		recentMsgs, _ := h.getRecentMessages(ctx, chatAreaID, 10)
-		score, reason := h.relevanceAgentEvaluate(ctx, msg, recentMsgs, rs.BotName)
+		score, reason := h.relevanceAgentEvaluate(ctx, msg, recentMsgs, rs)
 		if score < rs.RelevanceThreshold {
 			log.Debug("回复策略: 相关性不足", "score", score, "threshold", rs.RelevanceThreshold, "reason", reason)
 			return false

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -455,9 +455,9 @@ func (h *HagoCenter) handleMessage(ctx context.Context, events []adapter.Event, 
 		instruction += "\n\n" + spc
 	}
 	if agentLite {
-		instruction = "【AgentLite 精简模式】你无法使用任何工具、MCP 或外部能力。" +
-			"如果用户提出的任务需要工具或外部操作才能完成（如发送消息、查天气、生成图片、执行代码、搜索等），" +
-			"直接拒绝并说明当前处于精简模式无法执行该操作。回复中不要假装已经完成了需要工具的任务。\n\n" + instruction
+		instruction = "【AgentLite 精简模式】当前仅禁用了 MCP 服务器、沙箱（代码/命令执行、浏览器搜索）和文生图工具，" +
+			"其余能力与正常模式一致，仍保留 ReAct 循环并可调用消息发送等其他工具。" +
+			"若用户请求涉及这些已禁用的能力，请如实说明当前不可用，不要假装已经执行。\n\n" + instruction
 	}
 
 	// 将 per-message 状态注入 context（避免 HagoCenter 共享字段数据竞争）
@@ -468,7 +468,7 @@ func (h *HagoCenter) handleMessage(ctx context.Context, events []adapter.Event, 
 		DynamicInstruction: instruction,
 		AgentLite:          agentLite,
 		StripMarkdown:      rs.StripMarkdown,
-		DisableSplit:       rs.AgentLite,
+		DisableSplit:       false,
 		LoopID:             loopID,
 	}
 	ctx = WithMsgSessionCtx(ctx, msgCtx)
@@ -589,12 +589,8 @@ var urlRegexp = regexp.MustCompile(`https?://\S+`)
 // sendReply 解析 CQ 码并组装消息段发送。
 // rs 从调用链传入，避免读取 HagoCenter 共享字段导致数据竞争。
 func (h *HagoCenter) sendReply(msg *adapter.MessageEvent, content string, rs ReplySettings) {
-	var parts []string
-	if rs.AgentLite {
-		parts = []string{content}
-	} else {
-		parts = splitMessages(content)
-	}
+	// AgentLite 与正常模式一致，同样支持分段回复
+	parts := splitMessages(content)
 	for _, part := range parts {
 		if rs.StripMarkdown {
 			part = stripMarkdown(part)

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -319,14 +319,14 @@ func (h *HagoCenter) handleMessage(ctx context.Context, events []adapter.Event, 
 		}
 	}
 
-	// 逐条 ACL 检查（无权限的消息从批次中剔除）
+	// 聊天黑名单检查：命中黑名单的消息直接丢弃（不进入 Agent 循环）
 	kept := events[:0]
 	for _, ev := range events {
 		m := ev.Message
 		if isAdmin(m.UserID, ev.Admins) || h.ACL.CheckChat(ctx, m.UserID, chatArea.ID) {
 			kept = append(kept, ev)
 		} else {
-			log.Info("ACL 拒绝", "user_id", m.UserID, "chat_area_id", chatArea.ID)
+			log.Info("聊天黑名单丢弃消息", "user_id", m.UserID, "chat_area_id", chatArea.ID)
 		}
 	}
 	if len(kept) == 0 {

--- a/internal/agent/reply_strategy.go
+++ b/internal/agent/reply_strategy.go
@@ -20,8 +20,10 @@ type RelevanceCheckResult struct {
 }
 
 // relevanceAgentEvaluate 调用 LLM 评估消息相关性。
+// 支持自定义提示词（rs.RelevancePrompt）与指定 Text 模型（rs.RelevanceModel）。
 // 返回 0-1 之间的相关性分数，以及原因。
-func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.MessageEvent, recentMessages []string, botName string) (float64, string) {
+func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.MessageEvent, recentMessages []string, rs ReplySettings) (float64, string) {
+	botName := rs.BotName
 	// 获取机器人 QQ，优先 Adapter 实时值（防止缓存为 0）
 	selfQQ := h.SelfQQ
 	if h.Adapter != nil {
@@ -84,8 +86,13 @@ func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.Me
 		return 0, "无法获取图片内容"
 	}
 
-	// 文本消息，调用文本模型
+	// 文本消息，调用文本模型（支持指定相关性检测专用模型）
 	llm := h.Providers.SelectModel(provider.ModelTypeText)
+	if rs.RelevanceModel != "" {
+		if p, ok := h.Providers.GetProvider(rs.RelevanceModel); ok && p.Type() == provider.ModelTypeText {
+			llm = p
+		}
+	}
 	if llm == nil {
 		return 0, "无可用 Text 模型"
 	}
@@ -97,6 +104,17 @@ func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.Me
 	}
 	contextStr += fmt.Sprintf("\n当前消息 (发送者: %s, QQ: %d):\n%s",
 		msg.Sender.Nickname, msg.UserID, msg.RawMessage)
+
+	// 回复规则：用户自定义提示词优先，否则使用默认规则
+	rules := rs.RelevancePrompt
+	if rules == "" {
+		rules = fmt.Sprintf(`- 如果消息明确指向你（@你、叫你的名字"%s"或"%s"、称呼"机器人"/"bot"、询问你的能力、请求你操作），相关度应该高（>0.7）
+- 如果消息是群友之间的闲聊、互怼、讨论与你无关的话题，相关度应该低（<0.3）
+- 如果消息是群管理相关需求（踢人、禁言等），即使没有@你，相关度也应该高
+- 如果消息是群友之间互相求助且没有@你，相关度应该低
+- 如果消息是纯表情、无意义内容，相关度应该低
+- 如果群聊处于热聊状态（多人连续发言讨论同一话题），可以适当提高相关度（0.3-0.5）`, h.SelfNickname, botName)
+	}
 
 	prompt := fmt.Sprintf(`你是一个群聊相关度判断助手。请根据以下群聊上下文判断当前消息是否与你（机器人）相关，是否需要你回复。
 
@@ -111,18 +129,13 @@ func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.Me
 - 发送者QQ: %d
 
 回复规则:
-- 如果消息明确指向你（@你、叫你的名字"%s"或"%s"、称呼"机器人"/"bot"、询问你的能力、请求你操作），相关度应该高（>0.7）
-- 如果消息是群友之间的闲聊、互怼、讨论与你无关的话题，相关度应该低（<0.3）
-- 如果消息是群管理相关需求（踢人、禁言等），即使没有@你，相关度也应该高
-- 如果消息是群友之间互相求助且没有@你，相关度应该低
-- 如果消息是纯表情、无意义内容，相关度应该低
-- 如果群聊处于热聊状态（多人连续发言讨论同一话题），可以适当提高相关度（0.3-0.5）
+%s
 
 请以 JSON 格式回复，只包含 JSON 对象，不要有其他内容:
 {"relevance": 0.0-1.0, "reason": "简短原因"}
 
 上下文:
-%s`, botName, h.SelfNickname, selfQQ, selfQQ, msg.Sender.Nickname, msg.UserID, h.SelfNickname, botName, contextStr)
+%s`, botName, h.SelfNickname, selfQQ, selfQQ, msg.Sender.Nickname, msg.UserID, rules, contextStr)
 
 	messages := []provider.ChatMessage{
 		{Role: "system", Content: "你是一个群聊相关性判断助手。请以 JSON 格式回复。"},

--- a/internal/api/dto/request.go
+++ b/internal/api/dto/request.go
@@ -256,4 +256,6 @@ type UpdateReplyStrategyReq struct {
 	BotName            string  `json:"bot_name"`
 	StripMarkdown      bool    `json:"strip_markdown"`
 	AgentLite          bool    `json:"agent_lite"`
+	RelevancePrompt    string  `json:"relevance_prompt"` // 相关性检测自定义提示词（空则用默认）
+	RelevanceModel     string  `json:"relevance_model"`  // 相关性检测使用的 Text Provider ID（空则用默认）
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -309,4 +309,6 @@ type ReplyStrategyResp struct {
 	BotName            string  `json:"bot_name"`
 	StripMarkdown      bool    `json:"strip_markdown"`
 	AgentLite          bool    `json:"agent_lite"`
+	RelevancePrompt    string  `json:"relevance_prompt"` // 相关性检测自定义提示词
+	RelevanceModel     string  `json:"relevance_model"`  // 相关性检测使用的 Text Provider ID
 }

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -1844,6 +1844,8 @@ func (s *Service) GetReplyStrategy(ctx context.Context, c *app.RequestContext) {
 		BotName:            cfg.BotName,
 		StripMarkdown:      cfg.StripMarkdown,
 		AgentLite:          cfg.AgentLite,
+		RelevancePrompt:    cfg.RelevancePrompt,
+		RelevanceModel:     cfg.RelevanceModel,
 	}))
 }
 
@@ -1888,6 +1890,8 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 	cfg.BotName = data.BotName
 	cfg.StripMarkdown = data.StripMarkdown
 	cfg.AgentLite = data.AgentLite
+	cfg.RelevancePrompt = data.RelevancePrompt
+	cfg.RelevanceModel = data.RelevanceModel
 
 	if err := s.DAO.ReplyStrategy.Update(ctx, cfg); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
@@ -1900,6 +1904,8 @@ func (s *Service) UpdateReplyStrategy(ctx context.Context, c *app.RequestContext
 		BotName:            cfg.BotName,
 		StripMarkdown:      cfg.StripMarkdown,
 		AgentLite:          cfg.AgentLite,
+		RelevancePrompt:    cfg.RelevancePrompt,
+		RelevanceModel:     cfg.RelevanceModel,
 	}))
 }
 

--- a/internal/core/acl/acl.go
+++ b/internal/core/acl/acl.go
@@ -2,7 +2,6 @@ package acl
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"JuanNiang-Neo/internal/core/dao"
@@ -21,14 +20,12 @@ func NewACL(dao *dao.ACLDAO) *ACL {
 	return &ACL{dao: dao}
 }
 
-// Check 检查 userID 在 chatAreaID 中是否可执行 scope 对应的操作。
-// 逻辑:
+// Check 检查 userID 在 chatAreaID 中是否被聊天黑名单禁止使用 Agent 循环。
+// 黑名单语义:
 //   - 无规则 = 允许所有（默认）
-//   - deny all  = 拒绝所有用户
-//   - deny list = 拒绝指定用户
-//   - allow all = 允许所有用户
-//   - allow list = 仅允许指定用户（白名单）
-//   - 优先级: deny > allow，有 allow 规则时未命中则拒绝。
+//   - deny all  = 禁止所有用户
+//   - deny list = 禁止指定用户列表
+// 命中黑名单返回 false（禁止），否则 true（允许）。allow/白名单不再生效。
 func (a *ACL) Check(ctx context.Context, userID int64, chatAreaID string, scope models.ACLScope) bool {
 	rules, err := a.dao.GetByChatAreaAndScope(ctx, chatAreaID, scope)
 	if err != nil {
@@ -40,52 +37,24 @@ func (a *ACL) Check(ctx context.Context, userID int64, chatAreaID string, scope 
 	}
 
 	uidStr := strconv.FormatInt(userID, 10)
-	hasAllowRules := false
-	allowHit := false
-
 	for _, rule := range rules {
-		switch rule.Permission {
-		case models.ACLPermissionDeny:
-			if rule.TargetType == models.ACLTargetAll {
-				return false
-			}
-			if rule.TargetType == models.ACLTargetList && containsUserID(rule.UserIDs, uidStr) {
-				return false
-			}
-		case models.ACLPermissionAllow:
-			hasAllowRules = true
-			if rule.TargetType == models.ACLTargetAll {
-				allowHit = true
-			}
-			if rule.TargetType == models.ACLTargetList && containsUserID(rule.UserIDs, uidStr) {
-				allowHit = true
-			}
+		// 仅 deny（黑名单）规则生效
+		if rule.Permission != models.ACLPermissionDeny {
+			continue
+		}
+		if rule.TargetType == models.ACLTargetAll {
+			return false
+		}
+		if rule.TargetType == models.ACLTargetList && containsUserID(rule.UserIDs, uidStr) {
+			return false
 		}
 	}
-
-	// 有 allow 规则时，未命中则拒绝；无 allow 规则则允许
-	return !hasAllowRules || allowHit
+	return true
 }
 
-// CheckChat 检查聊天权限。
+// CheckChat 检查聊天黑名单权限（ACL 现仅管理 Chat 行为）。
 func (a *ACL) CheckChat(ctx context.Context, userID int64, chatAreaID string) bool {
 	return a.Check(ctx, userID, chatAreaID, models.ACLScopeChat)
-}
-
-// CheckTool 检查工具调用权限。返回 (allowed, denialMessage)。
-func (a *ACL) CheckTool(ctx context.Context, userID int64, chatAreaID, toolName string) (bool, string) {
-	if a.Check(ctx, userID, chatAreaID, models.ACLScopeTool) {
-		return true, ""
-	}
-	return false, fmt.Sprintf("用户：%d的工具调用(%s)被禁止", userID, toolName)
-}
-
-// CheckMCP 检查 MCP 调用权限。返回 (allowed, denialMessage)。
-func (a *ACL) CheckMCP(ctx context.Context, userID int64, chatAreaID, toolName string) (bool, string) {
-	if a.Check(ctx, userID, chatAreaID, models.ACLScopeMCP) {
-		return true, ""
-	}
-	return false, fmt.Sprintf("用户：%d的MCP调用(%s)被禁止", userID, toolName)
 }
 
 // AddRule 添加 ACL 规则。

--- a/internal/core/acl/acl_test.go
+++ b/internal/core/acl/acl_test.go
@@ -73,24 +73,25 @@ func TestACL_DenyList(t *testing.T) {
 	}
 }
 
-func TestACL_AllowList(t *testing.T) {
+func TestACL_AllowRuleIgnored(t *testing.T) {
+	// 黑名单语义：allow（白名单）规则不再生效，仅 deny 规则会禁止用户。
 	acl := testACL(t)
 	ctx := context.Background()
 
 	rule := &models.ACLRule{
 		ChatAreaID: "area-2",
-		Scope:      models.ACLScopeTool,
+		Scope:      models.ACLScopeChat,
 		Permission: models.ACLPermissionAllow,
 		TargetType: models.ACLTargetList,
 		UserIDs:    models.JSONSlice{"123"},
 	}
 	acl.AddRule(ctx, rule)
 
-	if !acl.Check(ctx, 123, "area-2", models.ACLScopeTool) {
-		t.Error("user 123 should be allowed")
+	if !acl.Check(ctx, 123, "area-2", models.ACLScopeChat) {
+		t.Error("user 123 should be allowed (allow rule ignored)")
 	}
-	if acl.Check(ctx, 456, "area-2", models.ACLScopeTool) {
-		t.Error("user 456 should be denied (whitelist)")
+	if !acl.Check(ctx, 456, "area-2", models.ACLScopeChat) {
+		t.Error("user 456 should be allowed (no deny rule)")
 	}
 }
 

--- a/internal/core/models/models.go
+++ b/internal/core/models/models.go
@@ -50,8 +50,14 @@ func (j *JSONSlice) Scan(value any) error {
 	if value == nil {
 		return nil
 	}
-	b, ok := value.([]byte)
-	if !ok {
+	// 兼容 []byte（Postgres jsonb）与 string（SQLite 文本列）
+	var b []byte
+	switch v := value.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
 		return nil
 	}
 	return json.Unmarshal(b, j)

--- a/internal/core/models/reply_strategy.go
+++ b/internal/core/models/reply_strategy.go
@@ -18,8 +18,10 @@ type ReplyStrategyConfig struct {
 	Strategy           ReplyStrategy `gorm:"not null;default:'always'" json:"strategy"`
 	RelevanceThreshold float64       `gorm:"default:0.5" json:"relevance_threshold"`
 	BotName            string        `gorm:"default:''" json:"bot_name"`
-	StripMarkdown      bool          `gorm:"default:false" json:"strip_markdown"` // 是否去除 Agent 消息中的 Markdown 格式
-	AgentLite          bool          `gorm:"default:false" json:"agent_lite"`     // AgentLite 模式：不调用工具/MCP，无 Agent 循环
+	StripMarkdown      bool          `gorm:"default:false" json:"strip_markdown"`   // 是否去除 Agent 消息中的 Markdown 格式
+	AgentLite          bool          `gorm:"default:false" json:"agent_lite"`       // AgentLite 模式：不调用工具/MCP，无 Agent 循环
+	RelevancePrompt    string        `gorm:"type:text;default:''" json:"relevance_prompt"` // 相关性检测自定义提示词（空则用默认）
+	RelevanceModel     string        `gorm:"default:''" json:"relevance_model"`     // 相关性检测使用的 Text Provider ID（空则用默认）
 	CreatedAt          time.Time     `json:"created_at"`
 	UpdatedAt          time.Time     `json:"updated_at"`
 }

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -338,8 +338,8 @@ func (pe *PluginEngine) ListMaps() []map[string]any {
 			"description":    m.Description,
 			"permissions":    m.Permissions,
 			"is_system":      m.System,
-			"is_active":      true, // 已加载即视为 active
-			"supports_timer": p.SupportsTimer(),
+			"is_active":         true, // 已加载即视为 active
+			"supports_cronjob": p.SupportsCronJob(),
 		}
 		// 使用 Load 时的 name（目录名）查找命令，而非 manifest.Name
 		// 因为命令注册使用的 plugin 参数是 Load 的 name 参数
@@ -370,10 +370,10 @@ func (pe *PluginEngine) ListMaps() []map[string]any {
 				"author":         manifest.Author,
 				"description":    manifest.Description,
 				"permissions":    manifest.Permissions,
-				"is_system":      manifest.System,
-				"is_active":      manifest.Enabled, // 从 YAML enabled 字段读取，兼容旧版默认 true
-				"supports_timer": false,            // 未加载的插件无法检测，默认 false
-				"commands":       []map[string]any{},
+				"is_system":         manifest.System,
+				"is_active":         manifest.Enabled, // 从 YAML enabled 字段读取，兼容旧版默认 true
+				"supports_cronjob": false,             // 未加载的插件无法检测，默认 false
+				"commands":          []map[string]any{},
 			})
 		}
 	}
@@ -695,7 +695,16 @@ func (pe *PluginEngine) Dispatch(ev adapter.Event) DispatchResult {
 			pluginEvent.UserID = ev.Message.UserID
 			pluginEvent.GroupID = ev.Message.GroupID
 		}
-		consumed := pe.onCronJobLocked(pluginEvent)
+		// 解析 CronJob 配置的 Payload（JSON 字符串 → map，透传给 on_cronjob）
+		if ev.CronJobPayload != "" {
+			var p map[string]any
+			if err := json.Unmarshal([]byte(ev.CronJobPayload), &p); err == nil {
+				pluginEvent.Payload = p
+			} else {
+				log.Warn("CronJob: payload 解析失败", "payload", ev.CronJobPayload, "err", err)
+			}
+		}
+		consumed := pe.onCronJobLocked(pluginEvent, ev.CronJobPluginIDs)
 		return DispatchResult{Consumed: consumed, Event: ev}
 	case "message":
 		if ev.Message != nil {
@@ -791,8 +800,13 @@ func (pe *PluginEngine) dispatchMessageLocked(ev adapter.Event) DispatchResult {
 }
 
 // onCronJobLocked 派发 cronjob 事件给插件（需在持有读锁时调用）。
-func (pe *PluginEngine) onCronJobLocked(event EventData) bool {
-	for _, p := range pe.plugins {
+// pluginIDs 指定要通知的插件目录名列表；为空则通知所有插件。
+func (pe *PluginEngine) onCronJobLocked(event EventData, pluginIDs []string) bool {
+	for pluginName, p := range pe.plugins {
+		// 按 CronJob 配置的插件列表过滤
+		if len(pluginIDs) > 0 && !containsString(pluginIDs, pluginName) {
+			continue
+		}
 		fn := p.State.GetGlobal("on_cronjob")
 		if fn.Type() != lua.LTFunction {
 			continue
@@ -807,6 +821,16 @@ func (pe *PluginEngine) onCronJobLocked(event EventData) bool {
 		consumedRet := p.State.Get(-1)
 		p.State.Pop(1)
 		if consumedRet.Type() == lua.LTBool && bool(consumedRet.(lua.LBool)) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsString 检查字符串切片中是否包含目标值。
+func containsString(list []string, target string) bool {
+	for _, v := range list {
+		if v == target {
 			return true
 		}
 	}
@@ -908,9 +932,10 @@ func (pe *PluginEngine) luaTableToEvent(t *lua.LTable, original adapter.Event) a
 	return result
 }
 
-// SupportsTimer 检查插件是否支持定时任务回调（定义了 on_timer_call 全局函数）。
-func (p *LoadedPlugin) SupportsTimer() bool {
-	fn := p.State.GetGlobal("on_timer_call")
+// SupportsCronJob 检查插件是否支持定时任务回调（定义了 on_cronjob 全局函数）。
+// 注意：CronJob 实际调用的回调是 on_cronjob，而非 on_timer_call。
+func (p *LoadedPlugin) SupportsCronJob() bool {
+	fn := p.State.GetGlobal("on_cronjob")
 	return fn.Type() == lua.LTFunction
 }
 

--- a/web/mock/handlers.ts
+++ b/web/mock/handlers.ts
@@ -584,6 +584,26 @@ export const mockHandlers: MockHandler[] = [
     }
   },
 
+  // ============ Reply Strategy ============
+  {
+    method: 'GET', path: '/reply-strategy',
+    handler() {
+      return ok({
+        strategy: 'always',
+        relevance_threshold: 0.5,
+        bot_name: '小卷',
+        strip_markdown: false,
+        agent_lite: false,
+        relevance_prompt: '',
+        relevance_model: '',
+      })
+    }
+  },
+  {
+    method: 'PUT', path: '/reply-strategy',
+    handler({ body }) { return ok(body) }
+  },
+
   // ============ Logs ============
   {
     method: 'GET', path: '/logs',

--- a/web/mock/handlers.ts
+++ b/web/mock/handlers.ts
@@ -57,9 +57,9 @@ const tools = [
 
 // --- Plugins ---
 let plugins = [
-  { id: 'weather-plugin', name: 'weather-plugin', version: '1.2.0', path: 'data/pluggins/weather-plugin/', config: { api_key: '***', default_city: 'Beijing' }, is_active: true, created_at: now() },
-  { id: 'translate-plugin', name: 'translate-plugin', version: '0.5.0', path: 'data/pluggins/translate-plugin/', config: {}, is_active: false, created_at: now() },
-  { id: 'scheduler-plugin', name: 'scheduler-plugin', version: '1.0.1', path: 'data/pluggins/scheduler-plugin/', config: { timezone: 'Asia/Shanghai' }, is_active: true, created_at: now() },
+  { id: 'weather-plugin', name: 'weather-plugin', version: '1.2.0', path: 'data/pluggins/weather-plugin/', config: { api_key: '***', default_city: 'Beijing' }, is_active: true, supports_cronjob: true, created_at: now() },
+  { id: 'translate-plugin', name: 'translate-plugin', version: '0.5.0', path: 'data/pluggins/translate-plugin/', config: {}, is_active: false, supports_cronjob: false, created_at: now() },
+  { id: 'scheduler-plugin', name: 'scheduler-plugin', version: '1.0.1', path: 'data/pluggins/scheduler-plugin/', config: { timezone: 'Asia/Shanghai' }, is_active: true, supports_cronjob: true, created_at: now() },
 ]
 
 // --- ACL Rules ---
@@ -67,6 +67,10 @@ let aclRules = [
   { id: 1, chat_area_id: UUID(), scope: 'chat', permission: 'deny', target_type: 'all', user_ids: [], created_at: now() },
   { id: 2, chat_area_id: UUID(), scope: 'chat', permission: 'deny', target_type: 'list', user_ids: ['123456', '789012'], created_at: now() },
 ]
+
+// --- CronJobs ---
+let cronJobs: any[] = []
+let cronJobIdCounter = 1
 let aclIdCounter = 4
 
 // --- Chat Areas ---
@@ -479,6 +483,45 @@ export const mockHandlers: MockHandler[] = [
     handler({ params }) {
       aclRules = aclRules.filter((r) => r.id !== Number(params.id))
       return ok(null)
+    }
+  },
+
+  // ============ CronJobs ============
+  {
+    method: 'GET', path: '/cronjobs',
+    handler() { return ok(cronJobs) }
+  },
+  {
+    method: 'POST', path: '/cronjobs',
+    handler({ body }: any) {
+      const job = { id: `cron-${cronJobIdCounter++}`, created_at: now(), updated_at: now(), last_run_at: null, last_error: '', ...body }
+      cronJobs.unshift(job)
+      return ok(job)
+    }
+  },
+  {
+    method: 'PUT', path: '/cronjobs/:id',
+    handler({ params, body }: any) {
+      const idx = cronJobs.findIndex((j) => j.id === params.id)
+      if (idx === -1) return ok(null)
+      cronJobs[idx] = { ...cronJobs[idx], ...body, id: params.id, updated_at: now() }
+      return ok(cronJobs[idx])
+    }
+  },
+  {
+    method: 'DELETE', path: '/cronjobs/:id',
+    handler({ params }: any) {
+      cronJobs = cronJobs.filter((j) => j.id !== params.id)
+      return ok(null)
+    }
+  },
+  {
+    method: 'PUT', path: '/cronjobs/:id/toggle',
+    handler({ params, body }: any) {
+      const idx = cronJobs.findIndex((j) => j.id === params.id)
+      if (idx === -1) return ok(null)
+      cronJobs[idx].is_active = body.is_active
+      return ok(cronJobs[idx])
     }
   },
 

--- a/web/mock/handlers.ts
+++ b/web/mock/handlers.ts
@@ -64,9 +64,8 @@ let plugins = [
 
 // --- ACL Rules ---
 let aclRules = [
-  { id: 1, chat_area_id: UUID(), scope: 'chat', permission: 'allow', target_type: 'all', user_ids: [], created_at: now() },
-  { id: 2, chat_area_id: UUID(), scope: 'tool', permission: 'deny', target_type: 'list', user_ids: ['123456', '789012'], created_at: now() },
-  { id: 3, chat_area_id: UUID(), scope: 'mcp', permission: 'allow', target_type: 'list', user_ids: ['111111'], created_at: now() },
+  { id: 1, chat_area_id: UUID(), scope: 'chat', permission: 'deny', target_type: 'all', user_ids: [], created_at: now() },
+  { id: 2, chat_area_id: UUID(), scope: 'chat', permission: 'deny', target_type: 'list', user_ids: ['123456', '789012'], created_at: now() },
 ]
 let aclIdCounter = 4
 

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -230,6 +230,8 @@ export interface ReplyStrategyResp {
   bot_name: string
   strip_markdown: boolean
   agent_lite: boolean
+  relevance_prompt: string
+  relevance_model: string
 }
 export interface UpdateReplyStrategyReq {
   strategy: string
@@ -237,6 +239,8 @@ export interface UpdateReplyStrategyReq {
   bot_name: string
   strip_markdown: boolean
   agent_lite: boolean
+  relevance_prompt?: string
+  relevance_model?: string
 }
 
 export const replyStrategyApi = {

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -209,9 +209,10 @@ export interface CronJobResp {
   created_at: string; updated_at: string
 }
 export interface AddCronJobReq {
-  name: string; cron_expr: string; message: string; message_type: string
-  target_id: number; is_active: boolean
+  name: string; cron_expr: string; is_active: boolean
   plugin_ids: string[]; payload: string
+  // CronJob 仅进入 Plugin 链路，以下 Agent 相关字段已废弃
+  message?: string; message_type?: string; target_id?: number
 }
 
 export const cronJobApi = {

--- a/web/src/layouts/AppSidebar.vue
+++ b/web/src/layouts/AppSidebar.vue
@@ -81,6 +81,7 @@ const navGroups = [
       { title: 'LLM Providers', icon: 'mdi-brain', to: '/providers' },
       { title: 'MCP 服务器', icon: 'mdi-server-network', to: '/mcp' },
       { title: 'Webhook', icon: 'mdi-webhook', to: '/webhook' },
+      { title: 'CronJob', icon: 'mdi-timer-cog-outline', to: '/cronjobs' },
     ],
   },
   {
@@ -91,7 +92,6 @@ const navGroups = [
       { title: 'Skills', icon: 'mdi-lightning-bolt', to: '/skills' },
       { title: 'Tools', icon: 'mdi-tools', to: '/tools' },
       { title: 'Plugins', icon: 'mdi-puzzle', to: '/plugins' },
-      { title: 'CronJob', icon: 'mdi-timer-cog-outline', to: '/cronjobs' },
       { title: 'Sessions', icon: 'mdi-chat-processing-outline', to: '/sessions' },
       { title: 'Memory', icon: 'mdi-memory', to: '/memory' },
     ],
@@ -102,7 +102,7 @@ const navGroups = [
     items: [
       { title: 'Chat Areas', icon: 'mdi-forum-outline', to: '/chat-areas' },
       { title: 'Chat Records', icon: 'mdi-message-text-outline', to: '/chat-records' },
-      { title: 'ACL 规则', icon: 'mdi-shield-account-outline', to: '/acl' },
+      { title: '黑名单', icon: 'mdi-shield-account-outline', to: '/acl' },
       { title: 'Agent 循环', icon: 'mdi-brain', to: '/agent-loops' },
     ],
   },

--- a/web/src/views/ACLPage.vue
+++ b/web/src/views/ACLPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="page-header">
-      <div class="page-title">ACL 黑名单管理</div>
+      <div class="page-title">黑名单管理</div>
       <div class="page-subtitle">禁止指定 QQ / 全部 QQ 使用 Agent 循环，命中黑名单的消息直接丢弃</div>
     </div>
     <div class="d-flex justify-end mb-4"><v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增黑名单</v-btn></div>

--- a/web/src/views/ACLPage.vue
+++ b/web/src/views/ACLPage.vue
@@ -1,14 +1,23 @@
 <template>
   <div>
     <div class="page-header">
-      <div class="page-title">ACL 规则管理</div>
-      <div class="page-subtitle">管理聊天/工具/MCP 的访问控制规则</div>
+      <div class="page-title">ACL 黑名单管理</div>
+      <div class="page-subtitle">禁止指定 QQ / 全部 QQ 使用 Agent 循环，命中黑名单的消息直接丢弃</div>
     </div>
-    <div class="d-flex justify-end mb-4"><v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增规则</v-btn></div>
+    <div class="d-flex justify-end mb-4"><v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增黑名单</v-btn></div>
     <v-data-table :headers="headers" :items="items" :loading="loading">
-      <template #item.scope="{ item }"><v-chip size="small" variant="tonal" :color="item.scope==='chat'?'primary':item.scope==='tool'?'warning':'info'">{{ item.scope }}</v-chip></template>
-      <template #item.permission="{ item }"><v-chip size="small" variant="tonal" :color="item.permission==='allow'?'success':'error'">{{ item.permission }}</v-chip></template>
-      <template #item.target_type="{ item }">{{ item.target_type }}{{ item.target_type==='list' ? ' ('+(item.user_ids||[]).length+' 用户)' : '' }}</template>
+      <template #item.target_type="{ item }">
+        <v-chip size="small" variant="tonal" :color="item.target_type==='all'?'error':'warning'">
+          {{ item.target_type === 'all' ? '全部 QQ' : '指定 QQ' }}
+        </v-chip>
+      </template>
+      <template #item.user_ids="{ item }">
+        <div v-if="item.target_type === 'list'" class="d-flex flex-wrap" style="gap:4px">
+          <v-chip v-for="uid in (item.user_ids || [])" :key="uid" size="x-small" variant="tonal" color="error">{{ uid }}</v-chip>
+          <span v-if="!item.user_ids || item.user_ids.length === 0" class="text-caption text-medium-emphasis">(空)</span>
+        </div>
+        <span v-else class="text-caption text-medium-emphasis">—</span>
+      </template>
       <template #item.actions="{ item }">
         <v-btn icon="mdi-delete" size="small" variant="text" color="error" @click="confirmDelete(item)" />
       </template>
@@ -16,7 +25,7 @@
 
     <v-dialog v-model="dialog" max-width="560">
       <v-card rounded="lg">
-        <v-card-title>新增 ACL 规则</v-card-title>
+        <v-card-title>新增黑名单</v-card-title>
         <v-card-text>
           <v-form ref="formRef">
             <v-select
@@ -28,86 +37,81 @@
               class="mb-3"
               clearable
             />
-            <v-select v-model="form.scope" :items="['chat','tool','mcp']" label="范围" class="mb-3" @update:model-value="onScopeChange" />
-            <v-select v-model="form.permission" :items="['allow','deny']" label="权限" class="mb-3" />
-            <v-select v-model="form.target_type" :items="['all','list']" label="目标类型" class="mb-3" />
+            <v-select
+              v-model="form.target_type"
+              :items="[{ title: '全部 QQ', value: 'all' }, { title: '指定 QQ 列表', value: 'list' }]"
+              label="黑名单范围"
+              class="mb-3"
+              hint="全部 = 禁止所有 QQ 使用 Agent 循环；指定 = 仅禁止以下 QQ"
+              persistent-hint
+            />
             <v-combobox
               v-if="form.target_type === 'list'"
               v-model="form.user_ids"
-              label="目标 QQ 号列表"
+              label="QQ 号列表"
               multiple
               chips
               closable-chips
               hint="回车添加, 支持多个 QQ 号"
               class="mb-3"
             />
-            <v-select
-              v-if="form.scope === 'tool'"
-              v-model="form.tool_ids"
-              :items="aclToolOptions"
-              item-title="label"
-              item-value="value"
-              label="Tool 列表"
-              multiple
-              class="mb-3"
-            />
-            <v-select
-              v-if="form.scope === 'mcp'"
-              v-model="form.mcp_ids"
-              :items="mcpOptions"
-              item-title="label"
-              item-value="value"
-              label="MCP 服务器"
-              multiple
-              class="mb-3"
-            />
           </v-form>
         </v-card-text>
-        <v-card-actions><v-spacer /><v-btn variant="text" @click="dialog = false">取消</v-btn><v-btn color="primary" variant="tonal" @click="handleSave" :loading="saving">保存</v-btn></v-card-actions>
+        <v-card-actions><v-spacer /><v-btn variant="text" @click="dialog = false">取消</v-btn><v-btn color="error" variant="tonal" @click="handleSave" :loading="saving">保存</v-btn></v-card-actions>
       </v-card>
     </v-dialog>
 
-    <v-dialog v-model="deleteDialog" max-width="400"><v-card rounded="lg"><v-card-title>确认删除</v-card-title><v-card-text>确定要删除此 ACL 规则吗？</v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="deleteDialog = false">取消</v-btn><v-btn color="error" variant="tonal" @click="handleDelete" :loading="deleting">删除</v-btn></v-card-actions></v-card></v-dialog>
+    <v-dialog v-model="deleteDialog" max-width="400"><v-card rounded="lg"><v-card-title>确认删除</v-card-title><v-card-text>确定要删除此黑名单吗？</v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="deleteDialog = false">取消</v-btn><v-btn color="error" variant="tonal" @click="handleDelete" :loading="deleting">删除</v-btn></v-card-actions></v-card></v-dialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { aclApi, chatAreaApi, toolApi, mcpApi, type ACLRuleResp, type AddACLRuleReq, type ChatAreaResp, type ToolConfigResp, type MCPServerResp } from '@/api'
+import { aclApi, chatAreaApi, type ACLRuleResp, type AddACLRuleReq, type ChatAreaResp } from '@/api'
 import { useToastStore } from '@/stores/toast'
 
 const toastStore = useToastStore()
 const loading = ref(true); const items = ref<ACLRuleResp[]>([]); const dialog = ref(false); const deleteDialog = ref(false)
 const saving = ref(false); const deleting = ref(false); const deleteTarget = ref<ACLRuleResp | null>(null); const formRef = ref()
 const chatAreaItems = ref<{label: string; value: string}[]>([])
-const aclToolOptions = ref<{label: string; value: string}[]>([])
-const mcpOptions = ref<{label: string; value: string}[]>([])
-
-// 基础工具（不在 ACL 管理范围内）
-const excludedTools = ['send_msg', 'delete_msg', 't2i', 'send_private_msg', 'send_group_msg', 'send_like']
 
 const headers = [
-  { title: 'ID', key: 'id' }, { title: 'Chat Area', key: 'chat_area_id' }, { title: '范围', key: 'scope' },
-  { title: '权限', key: 'permission' }, { title: '目标', key: 'target_type' },
+  { title: 'ID', key: 'id' },
+  { title: 'Chat Area', key: 'chat_area_id' },
+  { title: '黑名单范围', key: 'target_type' },
+  { title: 'QQ 列表', key: 'user_ids' },
   { title: '操作', key: 'actions', align: 'center' as const, sortable: false },
 ]
 
-const defaultForm = (): AddACLRuleReq => ({ chat_area_id: '', scope: 'chat', permission: 'allow', target_type: 'all', user_ids: [], tool_ids: [], mcp_ids: [] })
-const form = ref<AddACLRuleReq>(defaultForm())
-
-function onScopeChange() {
-  if (form.value.scope !== 'tool') form.value.tool_ids = []
-  if (form.value.scope !== 'mcp') form.value.mcp_ids = []
-}
+type BlacklistTargetType = 'all' | 'list'
+const defaultForm = () => ({ chat_area_id: '', target_type: 'all' as BlacklistTargetType, user_ids: [] as string[] })
+const form = ref(defaultForm())
 
 async function fetch() { loading.value = true; try { items.value = (await aclApi.list()).data.data } catch { toastStore.error('获取失败') } finally { loading.value = false } }
 async function fetchChatAreas() { try { const list = (await chatAreaApi.list()).data.data || []; chatAreaItems.value = list.map((c: ChatAreaResp) => ({ label: `${c.area_type==='private'?'私聊':'群聊'} ${c.target_id} (${c.id.slice(0,8)})`, value: c.id })) } catch { toastStore.error('获取 ChatArea 列表失败') } }
-async function fetchToolOptions() { try { const list = (await toolApi.list()).data.data || []; aclToolOptions.value = list.filter((t: ToolConfigResp) => !excludedTools.includes(t.name)).map((t: ToolConfigResp) => ({ label: `${t.name}${t.is_builtin ? ' (内置)' : ''}`, value: t.name })) } catch { /* ignore */ } }
-async function fetchMcpOptions() { try { const list = (await mcpApi.list()).data.data || []; mcpOptions.value = list.map((m: MCPServerResp) => ({ label: m.name, value: m.name })) } catch { /* ignore */ } }
 
 function openAdd() { form.value = defaultForm(); dialog.value = true }
-async function handleSave() { saving.value = true; try { await aclApi.create(form.value); toastStore.success('已保存'); dialog.value = false; await fetch() } catch (e: any) { toastStore.error(e?.message || '保存失败') } finally { saving.value = false } }
+async function handleSave() {
+  if (!form.value.chat_area_id) { toastStore.error('请选择 Chat Area'); return }
+  if (form.value.target_type === 'list' && (!form.value.user_ids || form.value.user_ids.length === 0)) {
+    toastStore.error('请至少添加一个 QQ 号'); return
+  }
+  saving.value = true
+  try {
+    const data: AddACLRuleReq = {
+      chat_area_id: form.value.chat_area_id,
+      scope: 'chat',
+      permission: 'deny',
+      target_type: form.value.target_type,
+      user_ids: form.value.user_ids,
+    }
+    await aclApi.create(data)
+    toastStore.success('黑名单已保存')
+    dialog.value = false
+    await fetch()
+  } catch (e: any) { toastStore.error(e?.message || '保存失败') } finally { saving.value = false }
+}
 function confirmDelete(item: ACLRuleResp) { deleteTarget.value = item; deleteDialog.value = true }
 async function handleDelete() { if (!deleteTarget.value) return; deleting.value = true; try { await aclApi.delete(deleteTarget.value.id); toastStore.success('已删除'); deleteDialog.value = false; await fetch() } catch { toastStore.error('删除失败') } finally { deleting.value = false } }
-onMounted(() => { fetch(); fetchChatAreas(); fetchToolOptions(); fetchMcpOptions() })
+onMounted(() => { fetch(); fetchChatAreas() })
 </script>

--- a/web/src/views/CronJobsPage.vue
+++ b/web/src/views/CronJobsPage.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="page-header">
       <div class="page-title">CronJob 定时任务</div>
-      <div class="page-subtitle">在指定时间触发 Agent 消息或调用插件 on_timer_call 回调</div>
+      <div class="page-subtitle">在指定时间触发已配置插件的 on_cronjob 回调</div>
     </div>
     <div class="d-flex justify-end mb-4">
       <v-btn color="primary" prepend-icon="mdi-plus" @click="openAdd">新增任务</v-btn>
@@ -12,16 +12,11 @@
         <v-switch :model-value="item.is_active" color="primary" density="compact" hide-details
           @update:model-value="(v: any) => toggle(item.id, !!v)" />
       </template>
-      <template #item.dispatch_type="{ item }">
-        <v-chip v-if="item.plugin_ids && item.plugin_ids.length > 0" size="small" color="success" variant="tonal">Plugin</v-chip>
-        <v-chip v-if="item.message" size="small" color="info" variant="tonal" class="ml-1">Agent</v-chip>
-        <span v-if="!item.message && (!item.plugin_ids || item.plugin_ids.length === 0)" class="text-disabled">未配置</span>
-      </template>
       <template #item.plugin_ids="{ item }">
         <div class="d-flex flex-wrap" style="gap:4px" v-if="item.plugin_ids && item.plugin_ids.length > 0">
           <v-chip v-for="pid in item.plugin_ids" :key="pid" size="x-small" variant="tonal" color="success">{{ pid }}</v-chip>
         </div>
-        <span v-else class="text-disabled">-</span>
+        <span v-else class="text-disabled">未配置</span>
       </template>
       <template #item.last_run_at="{ item }">
         <span v-if="item.last_run_at">{{ new Date(item.last_run_at).toLocaleString() }}</span>
@@ -50,50 +45,31 @@
 
             <v-divider class="mb-3" />
 
-            <!-- Tab: Agent / Plugin -->
-            <v-tabs v-model="tab" color="primary" class="mb-4">
-              <v-tab value="agent">Agent 分发</v-tab>
-              <v-tab value="plugin">Plugin 分发</v-tab>
-            </v-tabs>
-
-            <v-window v-model="tab">
-              <!-- Agent 分发表单 -->
-              <v-window-item value="agent">
-                <v-select v-model="form.message_type" :items="msgTypeOptions" label="消息类型" class="mb-3" />
-                <v-text-field v-model.number="form.target_id" label="目标 ID (QQ号/群号)" type="number" class="mb-3" />
-                <v-textarea v-model="form.message" label="消息内容" class="mb-3" rows="3"
-                  hint="给 Agent 的用户消息。留空则不发给 Agent。" />
-              </v-window-item>
-
-              <!-- Plugin 分发表单 -->
-              <v-window-item value="plugin">
-                <v-select
-                  v-model="form.plugin_ids"
-                  :items="timerPlugins"
-                  item-title="name"
-                  item-value="id"
-                  label="触发插件"
-                  multiple
-                  chips
-                  closable-chips
-                  class="mb-3"
-                  hint="仅显示支持 on_timer_call 且已启用的插件"
-                  persistent-hint
-                />
-                <div class="text-caption text-medium-emphasis mb-1">Payload (JSON)</div>
-                <div class="editor-wrapper mb-3">
-                  <Codemirror
-                    v-model="form.payload"
-                    :extensions="cmExtensions"
-                    :style="{ height: '200px' }"
-                    :indent-with-tab="true"
-                    :tab-size="2"
-                    placeholder='{"target_qq": 123456, "message": "定时提醒"}'
-                  />
-                </div>
-                <div v-if="payloadError" class="text-error text-caption mb-2">{{ payloadError }}</div>
-              </v-window-item>
-            </v-window>
+            <v-select
+              v-model="form.plugin_ids"
+              :items="cronPlugins"
+              item-title="name"
+              item-value="id"
+              label="触发插件"
+              multiple
+              chips
+              closable-chips
+              class="mb-3"
+              hint="仅显示支持 on_cronjob 且已启用的插件"
+              persistent-hint
+            />
+            <div class="text-caption text-medium-emphasis mb-1">Payload (JSON)</div>
+            <div class="editor-wrapper mb-3">
+              <Codemirror
+                v-model="form.payload"
+                :extensions="cmExtensions"
+                :style="{ height: '200px' }"
+                :indent-with-tab="true"
+                :tab-size="2"
+                placeholder='{"target_qq": 123456, "message": "定时提醒"}'
+              />
+            </div>
+            <div v-if="payloadError" class="text-error text-caption mb-2">{{ payloadError }}</div>
           </v-form>
         </v-card-text>
         <v-card-actions>
@@ -133,17 +109,10 @@ const items = ref<CronJobResp[]>([])
 const dialog = ref(false); const deleteDialog = ref(false)
 const editing = ref<string | null>(null); const saving = ref(false); const deleting = ref(false)
 const deleteTarget = ref<CronJobResp | null>(null); const formRef = ref()
-const tab = ref('agent')
-
-const msgTypeOptions = [
-  { title: '私聊', value: 'private' },
-  { title: '群聊', value: 'group' },
-]
 
 const headers = [
   { title: '名称', key: 'name' },
   { title: 'Cron 表达式', key: 'cron_expr' },
-  { title: '分发类型', key: 'dispatch_type' },
   { title: '触发插件', key: 'plugin_ids' },
   { title: '上次执行', key: 'last_run_at' },
   { title: '上次错误', key: 'last_error' },
@@ -152,7 +121,7 @@ const headers = [
 ]
 
 const defaultForm = (): AddCronJobReq => ({
-  name: '', cron_expr: '', message: '', message_type: 'private', target_id: 0, is_active: true,
+  name: '', cron_expr: '', is_active: true,
   plugin_ids: [], payload: '',
 })
 
@@ -169,14 +138,14 @@ const payloadError = computed(() => {
   catch (e: any) { return `JSON 格式错误: ${e.message}` }
 })
 
-// 获取支持 on_timer_call 且启用的插件列表
-const timerPlugins = ref<Array<{ id: string; name: string }>>([])
-async function loadTimerPlugins() {
+// 获取支持 on_cronjob 且启用的插件列表
+const cronPlugins = ref<Array<{ id: string; name: string }>>([])
+async function loadCronPlugins() {
   try {
     const res = await pluginApi.list()
     const plugins = (res.data.data || []) as any[]
-    timerPlugins.value = plugins
-      .filter((p: any) => p.supports_timer && p.is_active)
+    cronPlugins.value = plugins
+      .filter((p: any) => p.supports_cronjob && p.is_active)
       .map((p: any) => ({ id: p.id || p.name, name: `${p.name} (v${p.version})` }))
   } catch { /* ignore */ }
 }
@@ -188,19 +157,16 @@ async function fetch() {
   finally { loading.value = false }
 }
 function openAdd() {
-  editing.value = null; form.value = defaultForm(); tab.value = 'agent'
-  loadTimerPlugins(); dialog.value = true
+  editing.value = null; form.value = defaultForm()
+  loadCronPlugins(); dialog.value = true
 }
 function openEdit(item: CronJobResp) {
   editing.value = item.id
   form.value = {
-    name: item.name, cron_expr: item.cron_expr, message: item.message,
-    message_type: item.message_type, target_id: item.target_id, is_active: item.is_active,
+    name: item.name, cron_expr: item.cron_expr, is_active: item.is_active,
     plugin_ids: item.plugin_ids || [], payload: item.payload || '',
   }
-  // 根据已有数据决定默认 tab
-  tab.value = (item.plugin_ids && item.plugin_ids.length > 0) ? 'plugin' : 'agent'
-  loadTimerPlugins()
+  loadCronPlugins()
   dialog.value = true
 }
 async function toggle(id: string, v: boolean) {
@@ -208,6 +174,9 @@ async function toggle(id: string, v: boolean) {
   catch { toastStore.error('操作失败') }
 }
 async function handleSave() {
+  if (!form.value.name?.trim()) { toastStore.error('请输入任务名称'); return }
+  if (!form.value.cron_expr?.trim()) { toastStore.error('请输入 Cron 表达式'); return }
+  if (!form.value.plugin_ids || form.value.plugin_ids.length === 0) { toastStore.error('请至少选择一个触发插件'); return }
   saving.value = true
   try {
     if (editing.value) await cronJobApi.update(editing.value, form.value)

--- a/web/src/views/PluginsPage.vue
+++ b/web/src/views/PluginsPage.vue
@@ -20,8 +20,8 @@
           <span v-if="!item.permissions || item.permissions.length === 0" class="text-caption text-medium-emphasis">(无)</span>
         </div>
       </template>
-      <template #item.supports_timer="{ item }">
-        <v-chip v-if="item.supports_timer" size="small" color="success" variant="tonal">支持</v-chip>
+      <template #item.supports_cronjob="{ item }">
+        <v-chip v-if="item.supports_cronjob" size="small" color="success" variant="tonal">支持</v-chip>
         <v-chip v-else size="small" color="grey" variant="tonal">不支持</v-chip>
       </template>
       <template #item.is_active="{ item }">
@@ -124,7 +124,7 @@ interface PluginItem {
   permissions?: string[]
   is_system?: boolean
   is_active?: boolean
-  supports_timer?: boolean
+  supports_cronjob?: boolean
   commands?: Array<{ path: string[]; description: string; usage: string; is_leaf: boolean }>
 }
 
@@ -143,7 +143,7 @@ const headers = [
   { title: '名称', key: 'name' },
   { title: '版本', key: 'version' },
   { title: '权限', key: 'permissions' },
-  { title: '定时支持', key: 'supports_timer', align: 'center' as const },
+  { title: 'Cron 支持', key: 'supports_cronjob', align: 'center' as const },
   { title: '类型', key: 'is_system' },
   { title: 'Active', key: 'is_active', align: 'center' as const },
   { title: '操作', key: 'actions', align: 'center' as const, sortable: false },

--- a/web/src/views/ReplyStrategyPage.vue
+++ b/web/src/views/ReplyStrategyPage.vue
@@ -64,26 +64,17 @@
                     placeholder="（默认 Text 模型）"
                     density="comfortable" variant="outlined" clearable hide-details
                   />
-
-                  <v-divider class="my-3" />
-
-                  <div class="text-subtitle-2 font-weight-bold mb-2">自定义判断提示词</div>
-                  <v-textarea
-                    v-model="form.relevance_prompt"
-                    label="留空使用默认规则；填写后替换默认的「回复规则」"
-                    rows="5"
-                    density="comfortable" variant="outlined" hide-details
-                    placeholder="例如：\n- 只有直接@机器人或请求机器人办事的消息才算相关\n- 群友闲聊一律不回复（相关度 < 0.1）"
-                  />
-                  <div class="text-caption text-medium-emphasis mt-2">
-                    自定义提示词将替换相关性判断的「回复规则」部分，消息上下文仍会自动附加。
-                  </div>
                 </v-card>
               </v-expand-transition>
 
-              <v-btn type="submit" color="primary" variant="tonal" :loading="saving" :disabled="!form.strategy">
-                <v-icon class="me-1">mdi-content-save</v-icon> 保存
-              </v-btn>
+              <div class="d-flex align-center" style="gap: 12px">
+                <v-btn type="submit" color="primary" variant="tonal" :loading="saving" :disabled="!form.strategy">
+                  <v-icon class="me-1">mdi-content-save</v-icon> 保存
+                </v-btn>
+                <v-btn v-if="form.strategy === 'relevance'" variant="tonal" color="info" @click="openPromptDialog">
+                  <v-icon class="me-1">mdi-text-box-edit-outline</v-icon> 自定义判断提示词
+                </v-btn>
+              </div>
             </v-form>
           </v-card-text>
         </v-card>
@@ -131,6 +122,34 @@
         </v-card>
       </v-col>
     </v-row>
+    <!-- 自定义判断提示词弹窗 -->
+    <v-dialog v-model="promptDialog" max-width="720">
+      <v-card rounded="lg">
+        <v-card-title class="d-flex align-center justify-space-between pa-4">
+          <span>自定义判断提示词</span>
+          <v-btn icon="mdi-close" size="small" variant="text" @click="promptDialog = false" />
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="pa-4">
+          <v-textarea
+            v-model="promptDraft"
+            label="留空使用默认规则；填写后替换默认的「回复规则」"
+            rows="8"
+            density="comfortable" variant="outlined"
+            placeholder="例如：&#10;- 只有直接@机器人或请求机器人办事的消息才算相关&#10;- 群友闲聊一律不回复（相关度 < 0.1）"
+          />
+          <div class="text-caption text-medium-emphasis">
+            自定义提示词将替换相关性判断的「回复规则」部分，消息上下文仍会自动附加。
+          </div>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-spacer />
+          <v-btn variant="text" @click="promptDialog = false">取消</v-btn>
+          <v-btn color="primary" variant="tonal" @click="savePrompt">保存</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -141,6 +160,8 @@ import { replyStrategyApi, providerApi, type ProviderResp } from '@/api'
 
 const toastStore = useToastStore()
 const saving = ref(false)
+const promptDialog = ref(false)
+const promptDraft = ref('')
 
 const form = ref({
   strategy: 'always',
@@ -178,6 +199,17 @@ async function load() {
       form.value.relevance_model = d.relevance_model || ''
     }
   } catch (_e: any) {}
+}
+
+function openPromptDialog() {
+  promptDraft.value = form.value.relevance_prompt
+  promptDialog.value = true
+}
+
+function savePrompt() {
+  form.value.relevance_prompt = promptDraft.value
+  promptDialog.value = false
+  toastStore.success('提示词已更新，点击「保存」生效')
 }
 
 async function handleSave() {

--- a/web/src/views/ReplyStrategyPage.vue
+++ b/web/src/views/ReplyStrategyPage.vue
@@ -76,7 +76,7 @@
                 <div class="flex-grow-1 me-3">
                   <div class="text-subtitle-2 font-weight-bold">AgentLite 模式</div>
                   <div class="text-caption text-medium-emphasis mt-1">
-                    关闭工具/MCP 调用和 Agent 循环。消息直接发给 LLM，回复后即结束。<br />
+                    与正常模式一致，保留 ReAct 循环；仅禁用 MCP、沙箱和文生图工具。<br />
                     记忆、提示词、Skill 行为不受影响。
                   </div>
                 </div>

--- a/web/src/views/ReplyStrategyPage.vue
+++ b/web/src/views/ReplyStrategyPage.vue
@@ -51,6 +51,33 @@
                     placeholder="例如：小卷"
                     density="comfortable" variant="outlined" hide-details clearable
                   />
+
+                  <v-divider class="my-3" />
+
+                  <div class="text-subtitle-2 font-weight-bold mb-2">相关性检测模型</div>
+                  <v-select
+                    v-model="form.relevance_model"
+                    :items="textModelOptions"
+                    item-title="label"
+                    item-value="value"
+                    label="选择相关性判断使用的 Text 模型"
+                    placeholder="（默认 Text 模型）"
+                    density="comfortable" variant="outlined" clearable hide-details
+                  />
+
+                  <v-divider class="my-3" />
+
+                  <div class="text-subtitle-2 font-weight-bold mb-2">自定义判断提示词</div>
+                  <v-textarea
+                    v-model="form.relevance_prompt"
+                    label="留空使用默认规则；填写后替换默认的「回复规则」"
+                    rows="5"
+                    density="comfortable" variant="outlined" hide-details
+                    placeholder="例如：\n- 只有直接@机器人或请求机器人办事的消息才算相关\n- 群友闲聊一律不回复（相关度 < 0.1）"
+                  />
+                  <div class="text-caption text-medium-emphasis mt-2">
+                    自定义提示词将替换相关性判断的「回复规则」部分，消息上下文仍会自动附加。
+                  </div>
                 </v-card>
               </v-expand-transition>
 
@@ -110,7 +137,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useToastStore } from '@/stores/toast'
-import { replyStrategyApi } from '@/api'
+import { replyStrategyApi, providerApi, type ProviderResp } from '@/api'
 
 const toastStore = useToastStore()
 const saving = ref(false)
@@ -121,7 +148,21 @@ const form = ref({
   bot_name: '',
   strip_markdown: false,
   agent_lite: false,
+  relevance_prompt: '',
+  relevance_model: '',
 })
+
+// 相关性检测可选的 Text 模型列表（仅 text_model 类型）
+const textModelOptions = ref<{ label: string; value: string }[]>([])
+
+async function loadModels() {
+  try {
+    const list = (await providerApi.list()).data.data || []
+    textModelOptions.value = list
+      .filter((p: ProviderResp) => p.type === 'text_model')
+      .map((p: ProviderResp) => ({ label: `${p.name} · ${p.model}`, value: p.id }))
+  } catch { /* ignore */ }
+}
 
 async function load() {
   try {
@@ -133,6 +174,8 @@ async function load() {
       form.value.bot_name = d.bot_name || ''
       form.value.strip_markdown = d.strip_markdown || false
       form.value.agent_lite = d.agent_lite || false
+      form.value.relevance_prompt = d.relevance_prompt || ''
+      form.value.relevance_model = d.relevance_model || ''
     }
   } catch (_e: any) {}
 }
@@ -146,6 +189,8 @@ async function handleSave() {
       bot_name: form.value.bot_name,
       strip_markdown: form.value.strip_markdown,
       agent_lite: form.value.agent_lite,
+      relevance_prompt: form.value.relevance_prompt,
+      relevance_model: form.value.relevance_model,
     })
     toastStore.success('回复设置已保存')
   } catch (e: any) {
@@ -153,5 +198,5 @@ async function handleSave() {
   } finally { saving.value = false }
 }
 
-onMounted(() => { load() })
+onMounted(() => { load(); loadModels() })
 </script>


### PR DESCRIPTION

<img width="640" height="350" alt="Image_1784484103471_280" src="https://github.com/user-attachments/assets/62988ede-65c9-4eea-aa71-3887fdfa5f45" />


## 前端视觉重构

  - **主题**：中性近黑背景 + 靛蓝/紫罗兰主色，边框化低投影卡片，替代原深紫+粉色
  - **全局样式**：侧边栏（激活态色条）、卡片（hover辉光）、表格、弹窗全部重写
  - **登录页重做**：左图右表单 2:1 布局，Logo 左上角，品牌图带渐变边框
  - **仪表盘**：系统资源改为 Goroutine 环形仪表盘 + 内存/CPU 进度条
  - **聊天记录**：修复双分页器 + 筛选重置页码 + 点击行查看消息详情
  - **字体本地化**：5 个 woff2 下载至 `public/fonts/`，去除 CDN 依赖
  - **侧边栏**：CronJob 移入核心配置，ACL 更名黑名单

  ## 核心规则重构

  ### AgentLite 模式
  保留 ReAct 循环与分段回复，仅禁用 MCP、沙箱、文生图工具（中间件改为按名过滤，不再清空全部）

  ### ACL → 聊天黑名单
  简化为纯黑名单（deny all / deny list），移除 tool/mcp scope 和 allow 白名单。命中即丢弃消息不进入 Agent 循环

  ### 回复策略
  - 相关性检测支持**自定义提示词**（替换默认回复规则）+ **指定 Text 模型**（按 Provider ID 选择）
  - 前端：模型选择器 + 提示词弹窗编辑（按钮置于保存旁）

  ### CronJob 链路修复
  - 删除前端残留的 Agent 分发 Tab（CronJob 只进 Plugin）
  - 修复 Payload 传递：`event.payload` 透传给 Lua `on_cronjob`
  - PluginIDs 精确过滤插件（不再通知所有插件）
  - 支持检测改为 `supports_cronjob`（检查 `on_cronjob`，非从未调用的 `on_timer_call`）

  ## ✅ 验证

  - `go build` + `go vet` + ACL/DAO 单测全绿
  - `vue-tsc` + `vite build` 通过
  - mock 全端 API 正常