### PR TITLE
fix(agent): 基于 message_id 幂等去重，消除消息重复消费

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -86,6 +86,9 @@ type HagoCenter struct {
 
 	// EinoAgent 是 Eino ADK 的 ChatModelAgent，替代手写的 ReAct 循环。
 	EinoAgent *adk.ChatModelAgent
+
+	// msgDedup 消息去重器：过滤 WS 断线重连/多连接导致的同一条消息重复投递。
+	msgDedup *msgDedup
 }
 
 // memberInfoTTL 群成员信息缓存有效期（角色变更不频繁，10 分钟足够）。
@@ -125,8 +128,12 @@ func NewHagoCenter() *HagoCenter {
 		relevanceSem:    make(chan struct{}, relevanceSemLimit),
 		toolAdminOnly:   make(map[string]bool),
 		knowledgeLRU:    newKnowledgeLRU(50),
+		msgDedup:        newMsgDedup(dedupWindow),
 	}
 }
+
+// dedupWindow 消息去重窗口：需大于 WS 断线重连 + 重推积压的最长间隔。
+const dedupWindow = 60 * time.Second
 
 // Init 从 DB 加载配置并初始化所有子模块。
 func (h *HagoCenter) Init(ctx context.Context, cfg Config) error {

--- a/internal/agent/dedup.go
+++ b/internal/agent/dedup.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"sync"
+	"time"
+)
+
+// msgDedup 消息去重器：基于 OneBot11 message_id 过滤重复投递的消息。
+// 背景：WS 断线重连/多连接时，OneBot 客户端可能把同一条消息重复推送到
+// events channel（adapter 层不做去重），导致下游 Agent 重复消费。
+// message_id 在同一消息来源（群/私聊各自独立递增）内稳定，可作幂等键。
+type msgDedup struct {
+	mu   sync.Mutex
+	seen map[string]time.Time // key -> 首次记录时间（惰性过期清理）
+	ttl  time.Duration
+}
+
+// newMsgDedup 创建去重器，ttl 为去重窗口（需大于 WS 重连/重推的最长间隔）。
+func newMsgDedup(ttl time.Duration) *msgDedup {
+	return &msgDedup{
+		seen: make(map[string]time.Time),
+		ttl:  ttl,
+	}
+}
+
+// seenBefore 判断 key 是否在去重窗口内已出现过；未出现过则记录并返回 false。
+func (d *msgDedup) seenBefore(key string) bool {
+	now := time.Now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if ts, ok := d.seen[key]; ok && now.Sub(ts) < d.ttl {
+		return true
+	}
+	// 惰性清理：map 达到上限时删除过期条目，防止无界增长
+	if len(d.seen) >= 8192 {
+		for k, ts := range d.seen {
+			if now.Sub(ts) >= d.ttl {
+				delete(d.seen, k)
+			}
+		}
+	}
+	d.seen[key] = now
+	return false
+}

--- a/internal/agent/dedup_test.go
+++ b/internal/agent/dedup_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMsgDedupSeenBefore(t *testing.T) {
+	d := newMsgDedup(time.Minute)
+
+	if d.seenBefore("group:10086") {
+		t.Fatal("首次出现不应判为重复")
+	}
+	if !d.seenBefore("group:10086") {
+		t.Fatal("去重窗口内再次出现应判为重复")
+	}
+}
+
+func TestMsgDedupDistinctKeys(t *testing.T) {
+	d := newMsgDedup(time.Minute)
+
+	// 不同 message_id 互不影响
+	if d.seenBefore("group:10086") || d.seenBefore("group:10087") {
+		t.Fatal("不同 message_id 不应互斥")
+	}
+	// 群/私聊 message_id 空间独立，同号不互扰
+	if d.seenBefore("private:10086") {
+		t.Fatal("私聊与群聊的同号 message_id 不应互斥")
+	}
+	// 各自第二次出现才算重复
+	if !d.seenBefore("group:10086") || !d.seenBefore("private:10086") {
+		t.Fatal("各自的第二次出现应判为重复")
+	}
+}
+
+func TestMsgDedupExpiry(t *testing.T) {
+	d := newMsgDedup(50 * time.Millisecond)
+
+	if d.seenBefore("group:10086") {
+		t.Fatal("首次出现不应判为重复")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if d.seenBefore("group:10086") {
+		t.Fatal("TTL 过期后应可再次处理")
+	}
+}
+
+func TestMsgDedupConcurrent(t *testing.T) {
+	d := newMsgDedup(time.Minute)
+
+	const workers = 16
+	var wg sync.WaitGroup
+	// 并发投递同一 key：仅一个应返回 false（放行），其余全部判重
+	first := make(chan bool, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			first <- !d.seenBefore("group:10086")
+		}()
+	}
+	wg.Wait()
+	close(first)
+
+	allowed := 0
+	for v := range first {
+		if v {
+			allowed++
+		}
+	}
+	if allowed != 1 {
+		t.Fatalf("并发投递同一 key 应有且仅有 1 个放行，实际 %d", allowed)
+	}
+}

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -80,6 +80,16 @@ func (h *HagoCenter) runEventLoop(ctx context.Context) {
 
 // processEvent 三阶段架构：Plugin 拦截 → 消息过滤 → 回复策略 → Agent。
 func (h *HagoCenter) processEvent(ctx context.Context, ev adapter.Event) {
+	// Phase 0: 消息幂等去重。WS 断线重连/多连接时 OneBot 端可能重复推送同一条
+	// 消息（相同 message_id），重复消费会导致 Agent 重复执行任务与重复回复。
+	// 群/私聊的 message_id 各自独立递增，key 需带上 message_type。
+	if ev.PostType == "message" && ev.Message != nil && ev.Message.MessageID > 0 {
+		key := ev.Message.MessageType + ":" + strconv.FormatInt(ev.Message.MessageID, 10)
+		if h.msgDedup.seenBefore(key) {
+			log.Info("重复消息已丢弃", "message_id", ev.Message.MessageID, "message_type", ev.Message.MessageType, "user_id", ev.Message.UserID)
+			return
+		}
+	}
 	// Phase 1: Plugin 统一拦截
 	if h.PluginEngine != nil {
 		result := h.PluginEngine.Dispatch(ev)

--- a/internal/agent/event_dedup_test.go
+++ b/internal/agent/event_dedup_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"JuanNiang-Neo/internal/adapter"
+	"JuanNiang-Neo/internal/agent/prompt"
+	"JuanNiang-Neo/internal/agent/session"
+	"JuanNiang-Neo/internal/agent/skill"
+	"JuanNiang-Neo/internal/core"
+	"JuanNiang-Neo/internal/core/acl"
+	"JuanNiang-Neo/internal/core/dao"
+	"JuanNiang-Neo/internal/core/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newDedupTestHago 构造最小 HagoCenter：真实 DAO（sqlite 内存库）+ 空技能引擎。
+// Plugin / EinoAgent / Memory / Adapter 均为 nil，handleMessage 在写入
+// chat_records（user 角色）后提前返回，故 chat_records 行数 = 消费次数。
+func newDedupTestHago(t *testing.T) (*HagoCenter, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := core.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	bundle := dao.NewBundle(db)
+	h := NewHagoCenter()
+	h.DAO = bundle
+	h.ACL = acl.NewACL(bundle.ACL)
+	h.Session = session.NewSessionManager(bundle.Session, bundle.ChatRecord, bundle.TokenUsageDaily, nil)
+	h.Prompt = prompt.NewPromptManager(bundle.Prompt)
+	h.Skills = skill.NewSkillEngine()
+	return h, db
+}
+
+func groupMsg(id int64) adapter.Event {
+	return adapter.Event{
+		PostType: "message",
+		Message: &adapter.MessageEvent{
+			MessageType: "group",
+			MessageID:   id,
+			UserID:      123,
+			GroupID:     456,
+			RawMessage:  "你好",
+			Message:     []adapter.Segment{{Type: "text", Data: map[string]any{"text": "你好"}}},
+		},
+	}
+}
+
+func waitBatchConsumed(t *testing.T) {
+	t.Helper()
+	// 批处理窗口 1s，等待窗口结束且 timer 回调执行完（sqlite 写库同步）
+	time.Sleep(batchWindow + 500*time.Millisecond)
+}
+
+func countUserRecords(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var count int64
+	if err := db.Model(&models.ChatRecord{}).Where("role = ?", "user").Count(&count).Error; err != nil {
+		t.Fatalf("count chat_records: %v", err)
+	}
+	return count
+}
+
+// TestDuplicateMessageIDConsumedTwice 复现"一条消息被重复消费"：
+// WS 层将同一条 message_id 投递两次（断线重连重推 / 多连接重复投递），
+// 期望消费链路只处理一次。
+func TestDuplicateMessageIDConsumedTwice(t *testing.T) {
+	h, db := newDedupTestHago(t)
+	ctx := context.Background()
+
+	h.processEvent(ctx, groupMsg(10086))
+	h.processEvent(ctx, groupMsg(10086)) // 同一条消息再次投递
+
+	waitBatchConsumed(t)
+
+	if got := countUserRecords(t, db); got != 1 {
+		t.Fatalf("同一条 message_id=10086 被消费了 %d 次，期望 1 次", got)
+	}
+}
+
+// TestDistinctMessageIDsProcessedOnce 对照组：不同 message_id 各消费一次（防误杀）。
+func TestDistinctMessageIDsProcessedOnce(t *testing.T) {
+	h, db := newDedupTestHago(t)
+	ctx := context.Background()
+
+	h.processEvent(ctx, groupMsg(10086))
+	h.processEvent(ctx, groupMsg(10087))
+
+	waitBatchConsumed(t)
+
+	if got := countUserRecords(t, db); got != 2 {
+		t.Fatalf("两条不同消息应各自消费一次，实际消费 %d 次", got)
+	}
+}


### PR DESCRIPTION
WS 断线重连/多连接时 OneBot 端可能重复推送同一条消息（相同 message_id），
此前消费链路无去重，导致 Agent 重复执行任务与重复回复。现在 processEvent
入口按 message_type:message_id 去重（60s 窗口），并新增单测复现与验证。

💘 Generated with Crush

Assisted-by: Crush:deepseek-v4-flash