### PR TITLE
feat: 多协议 LLM 适配 + Provider 管理界面升级 + 内置工具与记忆优化

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -207,6 +207,9 @@ func (h *HagoCenter) Init(ctx context.Context, cfg Config) error {
 		func(ctx context.Context, folder string, limit int) (string, error) {
 			return h.listImagesForTool(ctx, folder, limit)
 		},
+		func(ctx context.Context, keyword string, limit int) (string, error) {
+			return h.searchImagesForTool(ctx, keyword, limit)
+		},
 		func(ctx context.Context) (string, error) {
 			return h.listStickerTagsForTool(ctx)
 		},
@@ -215,6 +218,9 @@ func (h *HagoCenter) Init(ctx context.Context, cfg Config) error {
 		},
 		func(ctx context.Context, keyword string, limit int) (string, error) {
 			return h.searchStickersForTool(ctx, keyword, limit)
+		},
+		func(ctx context.Context, keyword string, limit int) (string, error) {
+			return h.searchKnowledgeForTool(ctx, keyword, limit)
 		},
 	)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -169,6 +169,8 @@ func (h *HagoCenter) Init(ctx context.Context, cfg Config) error {
 		log.Warn("技能记忆预热失败", "err", err)
 	}
 	h.Memory = memory.NewMemoryGroup(st, lt, sm)
+	// 注入 Per-ChatArea 短期记忆配置读取源（cache → DB → 全局默认）
+	h.Memory.SetShortTermStore(cfg.DAO.ShortTermMemory)
 	// 设置 LLM Provider 供 Compact 中的技能记忆更新使用
 	h.Memory.LLMProvider = h.Providers.SelectModel(provider.ModelTypeText)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -249,16 +249,7 @@ func (h *HagoCenter) loadProviders(ctx context.Context) error {
 		if !p.IsActive {
 			continue
 		}
-		pr := provider.NewProvider(provider.ProviderConfig{
-			ID:             p.ID,
-			Name:           p.Name,
-			Type:           provider.ModelType(p.Type),
-			Endpoint:       p.Endpoint,
-			Token:          p.Token,
-			Model:          p.Model,
-			Temperature:    p.Temperature,
-			EnableThinking: p.EnableThinking,
-		})
+		pr := provider.NewProvider(provider.ProviderConfigFromModel(&p))
 		h.Providers.AddProvider(pr)
 	}
 	log.Info("Provider 加载完成", "count", len(list))

--- a/internal/agent/agent_operator.go
+++ b/internal/agent/agent_operator.go
@@ -27,16 +27,7 @@ func (h *HagoCenter) SetProviderActive(ctx context.Context, id string, active bo
 		if err != nil {
 			return err
 		}
-		h.Providers.AddProvider(provider.NewProvider(provider.ProviderConfig{
-			ID:             p.ID,
-			Name:           p.Name,
-			Type:           provider.ModelType(p.Type),
-			Endpoint:       p.Endpoint,
-			Token:          p.Token,
-			Model:          p.Model,
-			Temperature:    p.Temperature,
-			EnableThinking: p.EnableThinking,
-		}))
+		h.Providers.AddProvider(provider.NewProvider(provider.ProviderConfigFromModel(p)))
 	} else {
 		h.Providers.DelProvider(id)
 	}

--- a/internal/agent/image.go
+++ b/internal/agent/image.go
@@ -41,3 +41,38 @@ func (h *HagoCenter) listImagesForTool(ctx context.Context, folder string, limit
 	sb.WriteString("提示：发送时把 imgs:// 后面的 ID 换成上面列出的 ID 即可引用对应图片。")
 	return sb.String(), nil
 }
+
+// searchImagesForTool 供 Agent 内置工具 search_images 使用：按图片展示名称模糊搜索图床，
+// 返回 ID/名称/文件夹，LLM 拿到 ID 后可拼 [CQ:image,file=imgs://<ID>] 引用。
+func (h *HagoCenter) searchImagesForTool(ctx context.Context, keyword string, limit int) (string, error) {
+	if h.DAO == nil || h.DAO.Image == nil {
+		return "图床未初始化", nil
+	}
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return "请提供搜索关键词", nil
+	}
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+	list, err := h.DAO.Image.SearchByName(ctx, keyword, limit)
+	if err != nil {
+		return "", err
+	}
+	if len(list) == 0 {
+		return fmt.Sprintf("未找到名称包含 %q 的图床图片", keyword), nil
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "按名称 %q 搜索到 %d 张图床图片（引用格式 [CQ:image,file=imgs://图片ID]）：\n", keyword, len(list))
+	for i := range list {
+		img := &list[i]
+		name := strings.TrimSpace(img.Name)
+		if name == "" {
+			name = "(无名称)"
+		}
+		fmt.Fprintf(&sb, "- ID=%s 名称=%s 路径=%s 大小=%d字节\n",
+			img.ID, name, img.Folder, img.SizeBytes)
+	}
+	sb.WriteString("提示：发送时把 imgs:// 后面的 ID 换成上面列出的 ID 即可引用对应图片。")
+	return sb.String(), nil
+}

--- a/internal/agent/knowledge.go
+++ b/internal/agent/knowledge.go
@@ -238,3 +238,51 @@ func formatKnowledgeContext(items []models.KnowledgeItem) string {
 	}
 	return sb.String()
 }
+
+// searchKnowledgeForTool 供 Agent 内置工具 search_knowledge 使用：按关键词主动查询知识库，
+// 返回标题 + 内容片段，让 Agent 在对话中按需检索（区别于对话前自动注入的 buildKnowledgeContext）。
+func (h *HagoCenter) searchKnowledgeForTool(ctx context.Context, keyword string, limit int) (string, error) {
+	if h.DAO == nil || h.DAO.Knowledge == nil {
+		return "知识库未初始化", nil
+	}
+	keyword = strings.TrimSpace(preprocessKnowledgeQuery(keyword))
+	if keyword == "" {
+		return "请提供搜索关键词", nil
+	}
+	if limit <= 0 || limit > 20 {
+		limit = 5
+	}
+	items, err := h.DAO.Knowledge.Match(ctx, keyword, limit)
+	if err != nil {
+		return "", err
+	}
+	if len(items) == 0 {
+		return fmt.Sprintf("知识库中未找到与 %q 相关的内容", keyword), nil
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "按关键词 %q 检索到 %d 条知识：\n", keyword, len(items))
+	for _, it := range items {
+		content := strings.TrimSpace(it.Content)
+		// 截断过长的内容，避免占用过多 token
+		runes := []rune(content)
+		if len(runes) > 300 {
+			content = string(runes[:300]) + "…"
+		}
+		title := strings.TrimSpace(it.Title)
+		if title == "" {
+			title = "(无标题)"
+		}
+		if content == "" {
+			continue
+		}
+		sb.WriteString("- 【")
+		sb.WriteString(title)
+		sb.WriteString("】 ")
+		sb.WriteString(content)
+		sb.WriteString("\n")
+	}
+	if sb.Len() == 0 {
+		return fmt.Sprintf("知识库中未找到与 %q 相关的内容", keyword), nil
+	}
+	return sb.String(), nil
+}

--- a/internal/agent/memory/memory.go
+++ b/internal/agent/memory/memory.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"JuanNiang-Neo/internal/agent/memory/longterm"
 	"JuanNiang-Neo/internal/agent/memory/shortterm"
 	"JuanNiang-Neo/internal/agent/memory/skillmem"
 	"JuanNiang-Neo/internal/agent/provider"
+	"JuanNiang-Neo/internal/core/models"
 	"JuanNiang-Neo/internal/logging"
 )
 
@@ -18,19 +20,58 @@ var log = logging.NewModule("memory")
 type ShortTermMemoryConfig = shortterm.Config
 type LongTermMemoryConfig = longterm.Config
 
+// ShortTermStore 提供 Per-ChatArea 短期记忆配置的读取接口（由 core/dao 实现）。
+// MemoryGroup 通过该接口按 areaID 解析 AutoCompact / WindowSize，替代全局共享配置。
+type ShortTermStore interface {
+	GetOrCreate(ctx context.Context, chatAreaID string) (*models.ShortTermMemory, error)
+}
+
 type MemoryGroup struct {
 	ShortTerm   *shortterm.ShortTermMemory
 	LongTerm    *longterm.LongTermMemory
 	SkillMemory *skillmem.SkillMemory
 	LLMProvider provider.Provider // 用于 Compact 中的技能记忆更新
+
+	// per-ChatArea 短期记忆配置缓存（cache → DB → 全局默认）
+	shortTermStore  ShortTermStore
+	shortTermConfMu sync.Mutex
+	shortTermConf   map[string]ShortTermMemoryConfig
 }
 
 func NewMemoryGroup(st *shortterm.ShortTermMemory, lt *longterm.LongTermMemory, sm *skillmem.SkillMemory) *MemoryGroup {
 	return &MemoryGroup{
-		ShortTerm:   st,
-		LongTerm:    lt,
-		SkillMemory: sm,
+		ShortTerm:     st,
+		LongTerm:      lt,
+		SkillMemory:   sm,
+		shortTermConf: make(map[string]ShortTermMemoryConfig),
 	}
+}
+
+// SetShortTermStore 注入 Per-ChatArea 配置读取源（由 agent.Init 调用）。
+func (m *MemoryGroup) SetShortTermStore(store ShortTermStore) {
+	m.shortTermStore = store
+}
+
+// shortTermConfigFor 解析指定 ChatArea 的短期记忆配置：优先读缓存，未命中则查 DB，
+// 最后回退到全局实例默认值。解析结果缓存到内存 map，避免每次消息都查库。
+func (m *MemoryGroup) shortTermConfigFor(ctx context.Context, areaID string) ShortTermMemoryConfig {
+	m.shortTermConfMu.Lock()
+	defer m.shortTermConfMu.Unlock()
+	if c, ok := m.shortTermConf[areaID]; ok {
+		return c
+	}
+	c := ShortTermMemoryConfig{
+		WindowSize:  m.ShortTerm.WindowSize(),
+		AutoCompact: m.ShortTerm.AutoCompact(),
+	}
+	if m.shortTermStore != nil {
+		if got, err := m.shortTermStore.GetOrCreate(ctx, areaID); err == nil {
+			c.WindowSize = int64(got.WindowSize)
+			c.AutoCompact = got.AutoCompact
+		}
+	}
+	m.shortTermConf[areaID] = c
+	return c
 }
 
 // GetShortTermMessages 返回指定 ChatArea 当前短期记忆窗口内的消息。
@@ -39,16 +80,18 @@ func (m *MemoryGroup) GetShortTermMessages(ctx context.Context, areaID string) (
 }
 
 // AddShortTermMessage 向指定 ChatArea 的短期记忆追加一条消息。
-// 如果开启了 AutoCompact 且窗口已满，异步触发 Compact。
+// Per-ChatArea 配置解析后按该 area 的窗口维护滑动窗口；
+// 如果该 area 开启了 AutoCompact 且窗口已满，异步触发 Compact。
 func (m *MemoryGroup) AddShortTermMessage(ctx context.Context, areaID string, msg shortterm.ChatMessage) error {
-	if err := m.ShortTerm.Add(ctx, areaID, msg); err != nil {
+	conf := m.shortTermConfigFor(ctx, areaID)
+	if err := m.ShortTerm.AddWithWindow(ctx, areaID, msg, conf.WindowSize); err != nil {
 		return err
 	}
 
 	// AutoCompact: 窗口已满时异步触发 Compact（不阻塞消息处理）
-	if m.ShortTerm.AutoCompact() && m.LLMProvider != nil {
+	if conf.AutoCompact && m.LLMProvider != nil {
 		msgs, err := m.ShortTerm.GetAll(ctx, areaID)
-		if err == nil && int64(len(msgs)) >= m.ShortTerm.WindowSize() {
+		if err == nil && int64(len(msgs)) >= conf.WindowSize {
 			go func() {
 				compactCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 				defer cancel()
@@ -65,16 +108,22 @@ func (m *MemoryGroup) AddShortTermMessage(ctx context.Context, areaID string, ms
 }
 
 func (m *MemoryGroup) OverwriteShortTermMemory(ctx context.Context, areaID string, msgs []shortterm.ChatMessage) error {
-	return m.ShortTerm.Overwrite(ctx, areaID, msgs)
+	conf := m.shortTermConfigFor(ctx, areaID)
+	return m.ShortTerm.OverwriteWithWindow(ctx, areaID, msgs, conf.WindowSize)
 }
 
 func (m *MemoryGroup) CompactShortTermMemory(ctx context.Context, areaID string, llm provider.Provider) error {
 	return m.ShortTerm.Compact(ctx, areaID, llm, m)
 }
 
-func (m *MemoryGroup) UpdateShortTermConfig(conf ShortTermMemoryConfig) {
-	m.ShortTerm.SetWindowSize(conf.WindowSize)
-	m.ShortTerm.SetAutoCompact(conf.AutoCompact)
+// UpdateShortTermConfig 更新指定 ChatArea 的短期记忆配置缓存（运行时同步）。
+func (m *MemoryGroup) UpdateShortTermConfig(areaID string, conf ShortTermMemoryConfig) {
+	m.shortTermConfMu.Lock()
+	if m.shortTermConf == nil {
+		m.shortTermConf = make(map[string]ShortTermMemoryConfig)
+	}
+	m.shortTermConf[areaID] = conf
+	m.shortTermConfMu.Unlock()
 }
 
 func (m *MemoryGroup) AddLongTermMemory(ctx context.Context, areaID, content string) error {

--- a/internal/agent/memory/shortterm/shortterm.go
+++ b/internal/agent/memory/shortterm/shortterm.go
@@ -59,15 +59,24 @@ func (m *ShortTermMemory) key(areaID string) string {
 
 // Add 追加一条消息并维护滑动窗口（保留最近 WindowSize 条，最早在前）。
 func (m *ShortTermMemory) Add(ctx context.Context, areaID string, msg ChatMessage) error {
+	return m.AddWithWindow(ctx, areaID, msg, m.conf.WindowSize)
+}
+
+// AddWithWindow 追加一条消息并按指定的窗口大小维护滑动窗口（最早在前）。
+// Per-ChatArea 配置解析后由调用方传入该 area 的窗口大小，避免全局实例的共享配置互相覆盖。
+func (m *ShortTermMemory) AddWithWindow(ctx context.Context, areaID string, msg ChatMessage, windowSize int64) error {
 	if m.cache == nil {
 		return fmt.Errorf("shortterm cache 未初始化")
+	}
+	if windowSize <= 0 {
+		windowSize = m.conf.WindowSize
 	}
 	key := m.key(areaID)
 	if err := m.cache.RPush(ctx, key, msg); err != nil {
 		return err
 	}
-	// 仅保留最近 WindowSize 条
-	return m.cache.LTrim(ctx, key, -m.conf.WindowSize, -1)
+	// 仅保留最近 windowSize 条
+	return m.cache.LTrim(ctx, key, -windowSize, -1)
 }
 
 // GetAll 返回该 ChatArea 当前窗口内的全部消息（按时间最早→最新）。
@@ -84,8 +93,17 @@ func (m *ShortTermMemory) GetAll(ctx context.Context, areaID string) ([]ChatMess
 
 // Overwrite 用新列表覆盖窗口（先清空后追加）。
 func (m *ShortTermMemory) Overwrite(ctx context.Context, areaID string, msgs []ChatMessage) error {
+	return m.OverwriteWithWindow(ctx, areaID, msgs, m.conf.WindowSize)
+}
+
+// OverwriteWithWindow 用新列表覆盖窗口，并按指定的窗口大小截断。
+// Per-ChatArea 配置解析后由调用方传入该 area 的窗口大小。
+func (m *ShortTermMemory) OverwriteWithWindow(ctx context.Context, areaID string, msgs []ChatMessage, windowSize int64) error {
 	if m.cache == nil {
 		return fmt.Errorf("shortterm cache 未初始化")
+	}
+	if windowSize <= 0 {
+		windowSize = m.conf.WindowSize
 	}
 	key := m.key(areaID)
 	if err := m.cache.Del(ctx, key); err != nil {
@@ -101,7 +119,7 @@ func (m *ShortTermMemory) Overwrite(ctx context.Context, areaID string, msgs []C
 	if err := m.cache.RPush(ctx, key, args...); err != nil {
 		return err
 	}
-	return m.cache.LTrim(ctx, key, -m.conf.WindowSize, -1)
+	return m.cache.LTrim(ctx, key, -windowSize, -1)
 }
 
 // Clear 清空窗口。

--- a/internal/agent/provider/models_catalog.go
+++ b/internal/agent/provider/models_catalog.go
@@ -1,0 +1,88 @@
+package provider
+
+import "strings"
+
+// ---------- 模型能力元数据（§5.7，可选阶段） ----------
+// 数据源：MintWord aiProviders.ts 全量模型明细 + 2026-08 官方文档更新。
+// 用途：max_tokens 默认值校验、前端能力提示、后续上下文截断策略的基础。
+
+// ThinkingPattern 思考模式枚举（与 MintWord AiModel.thinkingPattern 对齐）。
+const (
+	ThinkingPatternReasoningEffort = "reasoning_effort" // openai 兼容: reasoning_effort 字段
+	ThinkingPatternThinkingObject  = "thinking_object"  // deepseek/kimi/zhipu/glm: thinking={type:enabled}
+	ThinkingPatternEnableThinking  = "enable_thinking"  // 通义/硅基: enable_thinking 布尔
+	ThinkingPatternThinkingConfig  = "thinking_config"  // gemini-3/stepfun
+	ThinkingPatternBudgetTokens    = "budget_tokens"    // anthropic 旧代/gemini 2.5
+	ThinkingPatternAdaptive        = "adaptive"         // anthropic 新代/minimax-M3
+	ThinkingPatternBuiltin         = "builtin"          // 模型内置思考，无参数
+)
+
+// ModelCapability 单个模型的能力元数据。
+type ModelCapability struct {
+	ContextWindow   int // token
+	MaxOutput       int // token
+	ThinkingSupport bool
+	ThinkingPattern string   // 见 ThinkingPattern 常量
+	SupportedParams []string // temperature, top_p, top_k, frequency_penalty, ...
+}
+
+// modelCatalog 模型能力表（初始数据，按厂商归并）。
+var modelCatalog = map[string]ModelCapability{
+	// OpenAI 系
+	"gpt-5.6-sol":   {ContextWindow: 1050000, MaxOutput: 128000, ThinkingPattern: ThinkingPatternReasoningEffort, SupportedParams: []string{"temperature", "top_p", "frequency_penalty", "presence_penalty"}},
+	"gpt-5.6-terra": {ContextWindow: 1050000, MaxOutput: 128000, ThinkingPattern: ThinkingPatternReasoningEffort, SupportedParams: []string{"temperature", "top_p", "frequency_penalty", "presence_penalty"}},
+	"gpt-5.6-luna":  {ContextWindow: 1050000, MaxOutput: 128000, ThinkingPattern: ThinkingPatternReasoningEffort, SupportedParams: []string{"temperature", "top_p", "frequency_penalty", "presence_penalty"}},
+	// Anthropic
+	"claude-opus-4-7":  {ContextWindow: 1000000, MaxOutput: 64000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternAdaptive, SupportedParams: []string{"temperature", "top_p", "top_k"}},
+	"claude-opus-5":    {ContextWindow: 1000000, MaxOutput: 128000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternAdaptive, SupportedParams: []string{}},
+	"claude-sonnet-5":  {ContextWindow: 1000000, MaxOutput: 128000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternAdaptive, SupportedParams: []string{}},
+	"claude-haiku-4-5": {ContextWindow: 200000, MaxOutput: 8000, SupportedParams: []string{"temperature", "top_p", "top_k"}},
+	// Gemini
+	"gemini-3-flash":        {ContextWindow: 1000000, MaxOutput: 65000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingConfig, SupportedParams: []string{"temperature", "top_p", "top_k", "repetition_penalty"}},
+	"gemini-3.6-flash":      {ContextWindow: 1000000, MaxOutput: 65000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingConfig, SupportedParams: []string{"temperature", "top_p", "top_k", "repetition_penalty"}},
+	"gemini-3.5-flash":      {ContextWindow: 1000000, MaxOutput: 65000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingConfig, SupportedParams: []string{"temperature", "top_p", "top_k", "repetition_penalty"}},
+	"gemini-3.5-flash-lite": {ContextWindow: 1000000, MaxOutput: 65000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingConfig, SupportedParams: []string{"temperature", "top_p", "top_k", "repetition_penalty"}},
+	"gemini-2.5-pro":        {ContextWindow: 1000000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternBudgetTokens, SupportedParams: []string{"temperature", "top_p", "top_k", "repetition_penalty"}},
+	// DeepSeek
+	"deepseek-v4-pro":   {ContextWindow: 1000000, MaxOutput: 384000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingObject, SupportedParams: []string{"temperature", "top_p", "frequency_penalty", "presence_penalty"}},
+	"deepseek-v4-flash": {ContextWindow: 1000000, MaxOutput: 384000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingObject, SupportedParams: []string{"temperature", "top_p", "frequency_penalty", "presence_penalty"}},
+	// Kimi
+	"kimi-k3":   {ContextWindow: 1000000, MaxOutput: 131000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternReasoningEffort, SupportedParams: []string{"temperature", "top_p"}},
+	"kimi-k2.6": {ContextWindow: 256000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingObject, SupportedParams: []string{"temperature", "top_p"}},
+	// 阿里
+	"qwen3.8-max":  {ContextWindow: 1000000, MaxOutput: 131000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternEnableThinking, SupportedParams: []string{"temperature", "top_p"}},
+	"qwen3.7-max":  {ContextWindow: 1000000, MaxOutput: 64000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternEnableThinking, SupportedParams: []string{"temperature", "top_p"}},
+	"qwen3.7-plus": {ContextWindow: 1000000, MaxOutput: 64000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternEnableThinking, SupportedParams: []string{"temperature", "top_p"}},
+	// 智谱
+	"glm-5.2": {ContextWindow: 1000000, MaxOutput: 131000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingObject, SupportedParams: []string{"temperature", "top_p"}},
+	"glm-5.1": {ContextWindow: 202000, MaxOutput: 131000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternThinkingObject, SupportedParams: []string{"temperature", "top_p"}},
+	// MiniMax
+	"minimax-m3": {ContextWindow: 1000000, MaxOutput: 128000, ThinkingSupport: true, ThinkingPattern: ThinkingPatternAdaptive, SupportedParams: []string{"temperature", "top_p", "top_k", "frequency_penalty", "presence_penalty", "repetition_penalty"}},
+	// 小米
+	"mimo-v2.5-pro": {ContextWindow: 1000000, MaxOutput: 128000, SupportedParams: []string{"temperature", "top_p"}},
+	"mimo-v2.5":     {ContextWindow: 1000000, MaxOutput: 128000, SupportedParams: []string{"temperature", "top_p"}},
+}
+
+// GetModelCapability 返回指定模型的能力元数据（按前缀模糊匹配，未命中返回零值）。
+func GetModelCapability(model string) (ModelCapability, bool) {
+	key := strings.ToLower(strings.TrimSpace(model))
+	if c, ok := modelCatalog[key]; ok {
+		return c, true
+	}
+	// 前缀匹配（如 deepseek-v4-flash-0731 → deepseek-v4-flash）
+	for k, c := range modelCatalog {
+		if strings.HasPrefix(key, k) && len(key) > len(k) {
+			return c, true
+		}
+	}
+	return ModelCapability{}, false
+}
+
+// ListModelCatalog 返回全部模型能力（供导出/测试）。
+func ListModelCatalog() map[string]ModelCapability {
+	out := make(map[string]ModelCapability, len(modelCatalog))
+	for k, v := range modelCatalog {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/agent/provider/provider.go
+++ b/internal/agent/provider/provider.go
@@ -10,13 +10,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
 
 var log = logging.NewModule("provider")
 
-// openAIProvider 实现 OpenAI-compatible API 客户端。
+// openAIProvider 实现多协议 LLM API 客户端：按 cfg.APIMode 分派
+// chat_completions / anthropic_messages / openai_responses / gemini_native。
 type openAIProvider struct {
 	cfg ProviderConfig
 	cli *http.Client
@@ -38,126 +41,104 @@ func (p *openAIProvider) Name() string    { return p.cfg.Name }
 func (p *openAIProvider) Type() ModelType { return p.cfg.Type }
 func (p *openAIProvider) Model() string   { return p.cfg.Model }
 
+// APIMode 返回归一化协议模式。
+func (p *openAIProvider) APIMode() APIMode { return p.cfg.apiMode() }
+
 // ---------- Chat ----------
 
 func (p *openAIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
-	body := p.buildChatBody(req, false)
-	respBody, err := p.doRequest(ctx, "/v1/chat/completions", body)
+	body, err := p.buildRequest(req, false)
 	if err != nil {
 		return nil, err
 	}
-	return p.parseChatResponse(respBody)
+	respBody, err := p.doRequest(ctx, p.endpointURL(), body)
+	if err != nil {
+		return nil, err
+	}
+	return p.parseResponse(respBody)
 }
 
 func (p *openAIProvider) ChatStream(ctx context.Context, req ChatRequest) (<-chan ChatStreamChunk, error) {
-	body := p.buildChatBody(req, true)
-	ch := make(chan ChatStreamChunk, 32)
-
-	reqURL := strings.TrimRight(p.cfg.Endpoint, "/") + "/v1/chat/completions"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	body, err := p.buildRequest(req, true)
 	if err != nil {
 		return nil, err
 	}
-	p.setHeaders(httpReq)
-
-	resp, err := p.cli.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("provider chat stream: %w", err)
-	}
-
-	go func() {
-		defer close(ch)
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			body, _ := io.ReadAll(resp.Body)
-			log.Error("provider stream 非200", "status", resp.StatusCode, "body", string(body))
-			return
-		}
-
-		scanner := bufio.NewScanner(resp.Body)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.HasPrefix(line, "data: ") {
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
-			if data == "[DONE]" {
-				return
-			}
-			var chunk rawStreamChunk
-			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-				log.Error("provider stream 解析失败", "err", err)
-				continue
-			}
-			if len(chunk.Choices) == 0 {
-				continue
-			}
-			choice := chunk.Choices[0]
-			out := ChatStreamChunk{
-				Content:      choice.Delta.Content,
-				FinishReason: choice.FinishReason,
-			}
-			for _, tc := range choice.Delta.ToolCalls {
-				out.ToolCalls = append(out.ToolCalls, ToolCall{
-					ID:   tc.ID,
-					Type: tc.Type,
-					Function: ToolCallFunc{
-						Name:      tc.Function.Name,
-						Arguments: json.RawMessage(tc.Function.Arguments),
-					},
-				})
-			}
-			select {
-			case ch <- out:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return ch, nil
+	return p.streamRequest(ctx, p.endpointURL(), body)
 }
 
 // ---------- Vision ----------
 
 func (p *openAIProvider) Vision(ctx context.Context, imageData []byte, prompt string) (string, error) {
 	imgB64 := base64.StdEncoding.EncodeToString(imageData)
-	imgURL := "data:image/jpeg;base64," + imgB64
-
-	reqBody := map[string]any{
-		"model": p.cfg.Model,
-		"messages": []map[string]any{
-			{
-				"role": "user",
-				"content": []map[string]any{
-					{"type": "text", "text": prompt},
-					{"type": "image_url", "image_url": map[string]string{"url": imgURL}},
-				},
-			},
-		},
-	}
-
-	data, err := json.Marshal(reqBody)
+	body, err := p.buildVisionRequest(imgB64, prompt)
 	if err != nil {
 		return "", err
 	}
-
-	respBody, err := p.doRequest(ctx, "/v1/chat/completions", data)
+	respBody, err := p.doRequest(ctx, p.endpointURL(), body)
 	if err != nil {
 		return "", err
 	}
-
-	chatResp, err := p.parseChatResponse(respBody)
+	chatResp, err := p.parseResponse(respBody)
 	if err != nil {
 		return "", err
 	}
 	return chatResp.Message.Content, nil
 }
 
-// ---------- 内部方法 ----------
+// ---------- URL 规则（§5.3，解决 Issue #22） ----------
 
-func (p *openAIProvider) buildChatBody(req ChatRequest, stream bool) []byte {
+// apiSuffixes 协议已知完整端点后缀：URL 以其结尾 → 视为完整端点，不再追加。
+var apiSuffixes = map[APIMode][]string{
+	APIModeChatCompletions:   {"/chat/completions"},
+	APIModeAnthropicMessages: {"/messages"},
+	APIModeOpenAIResponses:   {"/responses"},
+	APIModeGeminiNative:      {":generatecontent"},
+}
+
+// endpointURL 返回目标完整端点：base URL + 协议后缀自动拼接，或识别完整 URL、
+// 或 url_mode=exact 原样使用。
+func (p *openAIProvider) endpointURL() string {
+	if p.cfg.urlMode() == "exact" {
+		return p.cfg.Endpoint // 完全自定义：原样使用，不追加不识别
+	}
+	e := strings.TrimRight(p.cfg.Endpoint, "/")
+	if e == "" {
+		return ""
+	}
+	for _, s := range apiSuffixes[p.APIMode()] {
+		if strings.HasSuffix(strings.ToLower(e), s) {
+			return e // 用户已提供完整端点
+		}
+	}
+	switch p.APIMode() {
+	case APIModeGeminiNative:
+		return e + "/models/" + url.PathEscape(p.cfg.Model) + ":generateContent"
+	case APIModeAnthropicMessages:
+		return e + "/messages"
+	case APIModeOpenAIResponses:
+		return e + "/responses"
+	default:
+		return e + "/chat/completions"
+	}
+}
+
+// ---------- 请求构造（§5.2） ----------
+
+func (p *openAIProvider) buildRequest(req ChatRequest, stream bool) ([]byte, error) {
+	switch p.APIMode() {
+	case APIModeAnthropicMessages:
+		return p.buildAnthropic(req, stream)
+	case APIModeOpenAIResponses:
+		return p.buildResponses(req, stream)
+	case APIModeGeminiNative:
+		return p.buildGemini(req, stream)
+	default:
+		return p.buildChatCompletions(req, stream)
+	}
+}
+
+// buildChatCompletions OpenAI Chat Completions 协议。
+func (p *openAIProvider) buildChatCompletions(req ChatRequest, stream bool) ([]byte, error) {
 	messages := make([]map[string]any, 0, len(req.Messages))
 	for _, m := range req.Messages {
 		msg := map[string]any{"role": m.Role}
@@ -191,13 +172,26 @@ func (p *openAIProvider) buildChatBody(req ChatRequest, stream bool) []byte {
 		"model":    p.cfg.Model,
 		"messages": messages,
 	}
-	if req.Temperature > 0 {
-		body["temperature"] = req.Temperature
-	} else {
-		body["temperature"] = p.cfg.Temperature
+	if temp := p.resolveTemperature(req); temp > 0 {
+		body["temperature"] = temp
 	}
-	if req.MaxTokens > 0 {
-		body["max_tokens"] = req.MaxTokens
+	if mt := p.resolveMaxTokens(req, 0); mt > 0 {
+		body["max_tokens"] = mt
+	}
+	if p.cfg.TopP != nil {
+		body["top_p"] = *p.cfg.TopP
+	}
+	if p.cfg.TopK != nil {
+		body["top_k"] = *p.cfg.TopK
+	}
+	if p.cfg.FrequencyPenalty != nil {
+		body["frequency_penalty"] = *p.cfg.FrequencyPenalty
+	}
+	if p.cfg.PresencePenalty != nil {
+		body["presence_penalty"] = *p.cfg.PresencePenalty
+	}
+	if p.cfg.RepetitionPenalty != nil {
+		body["repetition_penalty"] = *p.cfg.RepetitionPenalty
 	}
 	if len(req.Tools) > 0 {
 		tools := make([]map[string]any, 0, len(req.Tools))
@@ -216,50 +210,393 @@ func (p *openAIProvider) buildChatBody(req ChatRequest, stream bool) []byte {
 	if stream {
 		body["stream"] = true
 	}
-	if p.cfg.EnableThinking {
-		// 模型思考开关：兼容主流 OpenAI 兼容实现的扩展字段。
-		//   DeepSeek 系: thinking={"type":"enabled"}; 通义千问系: enable_thinking=true。
-		// 未知字段通常被忽略，二者同时携带覆盖面最大。
-		body["thinking"] = map[string]any{"type": "enabled"}
-		body["enable_thinking"] = true
-	}
-
-	data, _ := json.Marshal(body)
-	return data
+	p.applyThinking(body, APIModeChatCompletions)
+	return json.Marshal(body)
 }
 
-func (p *openAIProvider) doRequest(ctx context.Context, path string, body []byte) ([]byte, error) {
-	url := strings.TrimRight(p.cfg.Endpoint, "/") + path
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("provider request: %w", err)
+// buildAnthropic Anthropic Messages 协议：system 独立字段、max_tokens 必填、tool_use/tool_result 结构。
+func (p *openAIProvider) buildAnthropic(req ChatRequest, stream bool) ([]byte, error) {
+	var system string
+	msgs := make([]map[string]any, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		if m.Role == "system" {
+			if system != "" {
+				system += "\n"
+			}
+			system += m.Content
+			continue
+		}
+		if m.Role == "tool" && m.ToolCallID != "" {
+			msgs = append(msgs, map[string]any{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": m.ToolCallID, "content": m.Content},
+				},
+			})
+			continue
+		}
+		role := "user"
+		if m.Role == "assistant" {
+			role = "assistant"
+		}
+		content := make([]map[string]any, 0, 1+len(m.ToolCalls))
+		if m.Content != "" {
+			content = append(content, map[string]any{"type": "text", "text": m.Content})
+		}
+		for _, tc := range m.ToolCalls {
+			content = append(content, map[string]any{
+				"type":  "tool_use",
+				"id":    tc.ID,
+				"name":  tc.Function.Name,
+				"input": json.RawMessage(tc.Function.Arguments),
+			})
+		}
+		msgs = append(msgs, map[string]any{"role": role, "content": content})
 	}
-	p.setHeaders(req)
 
-	resp, err := p.cli.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("provider do: %w", err)
+	body := map[string]any{
+		"model":      p.cfg.Model,
+		"max_tokens": p.resolveMaxTokens(req, 4096),
+		"messages":   msgs,
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("provider read: %w", err)
+	if system != "" {
+		body["system"] = system
 	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("provider %d: %s", resp.StatusCode, string(respBody))
+	if temp := p.resolveTemperature(req); temp > 0 {
+		body["temperature"] = temp
 	}
-
-	return respBody, nil
+	if p.cfg.TopP != nil {
+		body["top_p"] = *p.cfg.TopP
+	}
+	if p.cfg.TopK != nil {
+		body["top_k"] = *p.cfg.TopK
+	}
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"name":         t.Function.Name,
+				"description":  t.Function.Description,
+				"input_schema": json.RawMessage(t.Function.Parameters),
+			})
+		}
+		body["tools"] = tools
+	}
+	if stream {
+		body["stream"] = true
+	}
+	p.applyThinking(body, APIModeAnthropicMessages)
+	return json.Marshal(body)
 }
 
-func (p *openAIProvider) setHeaders(req *http.Request) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+p.cfg.Token)
+// buildResponses OpenAI Responses 协议：input 数组（非 messages）。
+func (p *openAIProvider) buildResponses(req ChatRequest, stream bool) ([]byte, error) {
+	input := make([]map[string]any, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		if m.ToolCallID != "" {
+			input = append(input, map[string]any{
+				"type":    "function_call_output",
+				"call_id": m.ToolCallID,
+				"output":  m.Content,
+			})
+			continue
+		}
+		item := map[string]any{"role": m.Role, "content": m.Content}
+		if len(m.ToolCalls) > 0 {
+			calls := make([]map[string]any, 0, len(m.ToolCalls))
+			for _, tc := range m.ToolCalls {
+				calls = append(calls, map[string]any{
+					"type":      "function_call",
+					"id":        tc.ID,
+					"call_id":   tc.ID,
+					"name":      tc.Function.Name,
+					"arguments": string(tc.Function.Arguments),
+				})
+			}
+			item["content"] = calls
+		}
+		input = append(input, item)
+	}
+
+	body := map[string]any{"model": p.cfg.Model, "input": input}
+	if mt := p.resolveMaxTokens(req, 0); mt > 0 {
+		body["max_output_tokens"] = mt
+	}
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"type":        "function",
+				"name":        t.Function.Name,
+				"description": t.Function.Description,
+				"parameters":  json.RawMessage(t.Function.Parameters),
+			})
+		}
+		body["tools"] = tools
+	}
+	if stream {
+		body["stream"] = true
+	}
+	p.applyThinking(body, APIModeOpenAIResponses)
+	return json.Marshal(body)
 }
 
-func (p *openAIProvider) parseChatResponse(body []byte) (*ChatResponse, error) {
+// buildGemini Gemini Generative Language 协议：contents[] / generationConfig / functionDeclarations。
+func (p *openAIProvider) buildGemini(req ChatRequest, stream bool) ([]byte, error) {
+	var systemParts []map[string]any
+	contents := make([]map[string]any, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		if m.Role == "system" {
+			systemParts = append(systemParts, map[string]any{"text": m.Content})
+			continue
+		}
+		role := "user"
+		if m.Role == "assistant" {
+			role = "model"
+		}
+		parts := make([]map[string]any, 0, 1+len(m.ToolCalls))
+		if m.Content != "" {
+			parts = append(parts, map[string]any{"text": m.Content})
+		}
+		for _, tc := range m.ToolCalls {
+			parts = append(parts, map[string]any{
+				"functionCall": map[string]any{
+					"name": tc.Function.Name,
+					"args": json.RawMessage(tc.Function.Arguments),
+				},
+			})
+		}
+		if m.ToolCallID != "" {
+			fnName := m.Name
+			if fnName == "" {
+				fnName = m.ToolCallID
+			}
+			parts = append(parts, map[string]any{
+				"functionResponse": map[string]any{
+					"name":     fnName,
+					"response": map[string]any{"result": m.Content},
+				},
+			})
+		}
+		contents = append(contents, map[string]any{"role": role, "parts": parts})
+	}
+
+	body := map[string]any{"contents": contents}
+	if len(systemParts) > 0 {
+		body["systemInstruction"] = map[string]any{"parts": systemParts}
+	}
+	genCfg := map[string]any{}
+	if temp := p.resolveTemperature(req); temp > 0 {
+		genCfg["temperature"] = temp
+	}
+	if p.cfg.TopP != nil {
+		genCfg["topP"] = *p.cfg.TopP
+	}
+	if p.cfg.TopK != nil {
+		genCfg["topK"] = *p.cfg.TopK
+	}
+	if p.cfg.RepetitionPenalty != nil {
+		genCfg["repetitionPenalty"] = *p.cfg.RepetitionPenalty
+	}
+	if mt := p.resolveMaxTokens(req, 8192); mt > 0 {
+		genCfg["maxOutputTokens"] = mt
+	}
+	if len(genCfg) > 0 {
+		body["generationConfig"] = genCfg
+	}
+	if len(req.Tools) > 0 {
+		fds := make([]map[string]any, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			params := json.RawMessage(t.Function.Parameters)
+			if len(params) == 0 {
+				params = json.RawMessage(`{}`)
+			}
+			fds = append(fds, map[string]any{
+				"name":        t.Function.Name,
+				"description": t.Function.Description,
+				"parameters":  params,
+			})
+		}
+		body["tools"] = []map[string]any{{"functionDeclarations": fds}}
+	}
+	if stream {
+		body["stream"] = true
+	}
+	p.applyThinking(body, APIModeGeminiNative)
+	return json.Marshal(body)
+}
+
+// ---------- 多模态请求构造（§5.6） ----------
+
+func (p *openAIProvider) buildVisionRequest(imgB64, prompt string) ([]byte, error) {
+	imgURL := "data:image/jpeg;base64," + imgB64
+	switch p.APIMode() {
+	case APIModeAnthropicMessages:
+		body := map[string]any{
+			"model":      p.cfg.Model,
+			"max_tokens": p.resolveMaxTokens(ChatRequest{}, 4096),
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{"type": "text", "text": prompt},
+						{"type": "image", "source": map[string]any{"type": "base64", "media_type": "image/jpeg", "data": imgB64}},
+					},
+				},
+			},
+		}
+		return json.Marshal(body)
+	case APIModeGeminiNative:
+		body := map[string]any{
+			"contents": []map[string]any{
+				{
+					"role": "user",
+					"parts": []map[string]any{
+						{"text": prompt},
+						{"inlineData": map[string]any{"mimeType": "image/jpeg", "data": imgB64}},
+					},
+				},
+			},
+		}
+		return json.Marshal(body)
+	case APIModeOpenAIResponses:
+		body := map[string]any{
+			"model": p.cfg.Model,
+			"input": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{"type": "input_text", "text": prompt},
+						{"type": "input_image", "image_url": imgURL, "detail": "auto"},
+					},
+				},
+			},
+		}
+		return json.Marshal(body)
+	default: // chat_completions
+		body := map[string]any{
+			"model": p.cfg.Model,
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{"type": "text", "text": prompt},
+						{"type": "image_url", "image_url": map[string]string{"url": imgURL}},
+					},
+				},
+			},
+		}
+		return json.Marshal(body)
+	}
+}
+
+// ---------- 响应解析（§5.2） ----------
+
+func (p *openAIProvider) parseResponse(body []byte) (*ChatResponse, error) {
+	switch p.APIMode() {
+	case APIModeAnthropicMessages:
+		return p.parseAnthropic(body)
+	case APIModeOpenAIResponses:
+		return p.parseResponses(body)
+	case APIModeGeminiNative:
+		return p.parseGemini(body)
+	default:
+		return p.parseChatCompletions(body)
+	}
+}
+
+func (p *openAIProvider) parseAnthropic(body []byte) (*ChatResponse, error) {
+	var raw struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+		StopReason string `json:"stop_reason"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("provider parseAnthropic: %w", err)
+	}
+	var text strings.Builder
+	for _, b := range raw.Content {
+		if b.Type == "text" {
+			text.WriteString(b.Text)
+		}
+	}
+	return &ChatResponse{
+		Message:      ChatMessage{Role: "assistant", Content: text.String()},
+		TokenUsage:   raw.Usage.InputTokens + raw.Usage.OutputTokens,
+		FinishReason: raw.StopReason,
+	}, nil
+}
+
+func (p *openAIProvider) parseResponses(body []byte) (*ChatResponse, error) {
+	var raw struct {
+		Output []struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+		Usage struct {
+			TotalTokens int `json:"total_tokens"`
+		} `json:"usage"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("provider parseResponses: %w", err)
+	}
+	var text strings.Builder
+	for _, o := range raw.Output {
+		for _, c := range o.Content {
+			if c.Text != "" {
+				text.WriteString(c.Text)
+			}
+		}
+	}
+	return &ChatResponse{
+		Message:      ChatMessage{Role: "assistant", Content: text.String()},
+		TokenUsage:   raw.Usage.TotalTokens,
+		FinishReason: raw.Status,
+	}, nil
+}
+
+func (p *openAIProvider) parseGemini(body []byte) (*ChatResponse, error) {
+	var raw struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+			FinishReason string `json:"finishReason"`
+		} `json:"candidates"`
+		UsageMetadata struct {
+			TotalTokenCount int `json:"totalTokenCount"`
+		} `json:"usageMetadata"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("provider parseGemini: %w", err)
+	}
+	if len(raw.Candidates) == 0 {
+		return nil, fmt.Errorf("provider parseGemini: 空响应")
+	}
+	c := raw.Candidates[0]
+	var text strings.Builder
+	for _, part := range c.Content.Parts {
+		text.WriteString(part.Text)
+	}
+	return &ChatResponse{
+		Message:      ChatMessage{Role: "assistant", Content: text.String()},
+		TokenUsage:   raw.UsageMetadata.TotalTokenCount,
+		FinishReason: c.FinishReason,
+	}, nil
+}
+
+func (p *openAIProvider) parseChatCompletions(body []byte) (*ChatResponse, error) {
 	var raw rawChatResponse
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("provider parse: %w", err)
@@ -291,6 +628,361 @@ func (p *openAIProvider) parseChatResponse(body []byte) (*ChatResponse, error) {
 		TokenUsage:   raw.Usage.TotalTokens,
 		FinishReason: choice.FinishReason,
 	}, nil
+}
+
+// ---------- HTTP 请求 ----------
+
+func (p *openAIProvider) doRequest(ctx context.Context, url string, body []byte) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("provider request: %w", err)
+	}
+	p.setHeaders(req)
+
+	resp, err := p.cli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("provider do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("provider read: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("provider %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// setHeaders 按 AuthHeader / 协议默认设置认证头。
+func (p *openAIProvider) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	auth := p.cfg.AuthHeader
+	if auth == "" {
+		switch p.APIMode() {
+		case APIModeAnthropicMessages:
+			auth = "x-api-key"
+		case APIModeGeminiNative:
+			auth = "x-goog-api-key"
+		default:
+			auth = "bearer"
+		}
+	}
+	switch strings.ToLower(auth) {
+	case "x-api-key":
+		req.Header.Set("x-api-key", p.cfg.Token)
+		if p.APIMode() == APIModeAnthropicMessages {
+			req.Header.Set("anthropic-version", "2023-06-01")
+		}
+	case "x-goog-api-key":
+		req.Header.Set("x-goog-api-key", p.cfg.Token)
+	case "api-key":
+		req.Header.Set("api-key", p.cfg.Token)
+	default: // bearer
+		req.Header.Set("Authorization", "Bearer "+p.cfg.Token)
+	}
+}
+
+// ---------- 流式 ----------
+
+func (p *openAIProvider) streamRequest(ctx context.Context, url string, body []byte) (<-chan ChatStreamChunk, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	p.setHeaders(httpReq)
+
+	resp, err := p.cli.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("provider chat stream: %w", err)
+	}
+
+	ch := make(chan ChatStreamChunk, 32)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			body, _ := io.ReadAll(resp.Body)
+			log.Error("provider stream 非200", "status", resp.StatusCode, "body", string(body))
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				return
+			}
+			for _, out := range p.parseStreamEvent(data) {
+				select {
+				case ch <- out:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			log.Error("provider stream 读取中断", "err", err)
+		}
+	}()
+
+	return ch, nil
+}
+
+func (p *openAIProvider) parseStreamEvent(data string) []ChatStreamChunk {
+	switch p.APIMode() {
+	case APIModeAnthropicMessages:
+		return p.parseAnthropicStreamEvent(data)
+	case APIModeGeminiNative:
+		return p.parseGeminiStreamEvent(data)
+	case APIModeOpenAIResponses:
+		return p.parseResponsesStreamEvent(data)
+	default:
+		return p.parseChatStreamEvent(data)
+	}
+}
+
+func (p *openAIProvider) parseChatStreamEvent(data string) []ChatStreamChunk {
+	var chunk rawStreamChunk
+	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		log.Error("provider stream 解析失败", "err", err)
+		return nil
+	}
+	if len(chunk.Choices) == 0 {
+		return nil
+	}
+	choice := chunk.Choices[0]
+	out := ChatStreamChunk{
+		Content:      choice.Delta.Content,
+		FinishReason: choice.FinishReason,
+	}
+	for _, tc := range choice.Delta.ToolCalls {
+		out.ToolCalls = append(out.ToolCalls, ToolCall{
+			ID:   tc.ID,
+			Type: tc.Type,
+			Function: ToolCallFunc{
+				Name:      tc.Function.Name,
+				Arguments: json.RawMessage(tc.Function.Arguments),
+			},
+		})
+	}
+	return []ChatStreamChunk{out}
+}
+
+func (p *openAIProvider) parseAnthropicStreamEvent(data string) []ChatStreamChunk {
+	var ev struct {
+		Type  string `json:"type"`
+		Delta struct {
+			Type       string `json:"type"`
+			Text       string `json:"text"`
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		return nil
+	}
+	switch ev.Type {
+	case "content_block_delta":
+		return []ChatStreamChunk{{Content: ev.Delta.Text}}
+	case "message_delta":
+		return []ChatStreamChunk{{FinishReason: ev.Delta.StopReason}}
+	}
+	return nil
+}
+
+func (p *openAIProvider) parseGeminiStreamEvent(data string) []ChatStreamChunk {
+	var ev struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+			FinishReason string `json:"finishReason"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		return nil
+	}
+	if len(ev.Candidates) == 0 {
+		return nil
+	}
+	c := ev.Candidates[0]
+	var text strings.Builder
+	for _, pt := range c.Content.Parts {
+		text.WriteString(pt.Text)
+	}
+	out := ChatStreamChunk{Content: text.String()}
+	if c.FinishReason != "" {
+		out.FinishReason = c.FinishReason
+	}
+	return []ChatStreamChunk{out}
+}
+
+func (p *openAIProvider) parseResponsesStreamEvent(data string) []ChatStreamChunk {
+	var ev struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+	}
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		return nil
+	}
+	if ev.Type == "response.output_text.delta" {
+		return []ChatStreamChunk{{Content: ev.Delta}}
+	}
+	return nil
+}
+
+// ---------- thinking 适配（§5.5） ----------
+
+// adaptiveModelRe 匹配 Anthropic 新代模型（使用 adaptive thinking，且不支持 extended thinking 的型号）。
+var adaptiveModelRe = regexp.MustCompile(`(?i)(opus-5|sonnet-5|fable-5|4-7|4-8|m3)`)
+
+func (p *openAIProvider) applyThinking(body map[string]any, mode APIMode) {
+	switch mode {
+	case APIModeAnthropicMessages:
+		p.applyThinkingAnthropic(body)
+	case APIModeGeminiNative:
+		p.applyThinkingGemini(body)
+	case APIModeOpenAIResponses:
+		p.applyThinkingResponses(body)
+	default:
+		p.applyThinkingChat(body)
+	}
+}
+
+// thinkingEffort 归一化档位：off/low/medium/high。EnableThinking 旧字段映射为 medium。
+func (p *openAIProvider) thinkingEffort() string {
+	if p.cfg.ThinkingEffort != "" {
+		return p.cfg.ThinkingEffort
+	}
+	if p.cfg.EnableThinking {
+		return "medium"
+	}
+	return "off"
+}
+
+// providerKey 判定厂商分组：优先 ProviderKey，否则按 Name 关键词匹配。
+func (p *openAIProvider) providerKey() string {
+	if p.cfg.ProviderKey != "" {
+		return normalizeProviderKey(p.cfg.ProviderKey)
+	}
+	n := strings.ToLower(p.cfg.Name)
+	for _, k := range []string{"deepseek", "kimi", "moonshot", "zhipu", "zai", "bigmodel", "alibaba", "dashscope", "qwen", "siliconflow", "stepfun", "minimax", "tencent", "hunyuan"} {
+		if strings.Contains(n, k) {
+			return k
+		}
+	}
+	return ""
+}
+
+func (p *openAIProvider) applyThinkingChat(body map[string]any) {
+	effort := p.thinkingEffort()
+	key := p.providerKey()
+	if effort == "off" {
+		switch key {
+		case "deepseek", "kimi", "moonshot", "zhipu", "zai", "bigmodel":
+			body["thinking"] = map[string]any{"type": "disabled"}
+		case "alibaba", "dashscope", "qwen", "siliconflow":
+			body["enable_thinking"] = false
+		}
+		return
+	}
+	switch key {
+	case "deepseek":
+		body["thinking"] = map[string]any{"type": "enabled"}
+		if strings.Contains(strings.ToLower(p.cfg.Model), "deepseek-v4") {
+			body["reasoning_effort"] = effort
+		}
+	case "kimi", "moonshot":
+		body["thinking"] = map[string]any{"type": "enabled"}
+		body["reasoning_effort"] = effort
+	case "zhipu", "zai", "bigmodel":
+		body["thinking"] = map[string]any{"type": "enabled"}
+		if strings.Contains(strings.ToLower(p.cfg.Model), "glm-5.2") {
+			body["reasoning_effort"] = effort
+		}
+	case "alibaba", "dashscope", "qwen", "siliconflow":
+		body["enable_thinking"] = true
+	case "stepfun":
+		body["reasoning_effort"] = effort
+	case "minimax":
+		body["reasoning_split"] = true
+	default:
+		body["reasoning_effort"] = effort
+	}
+}
+
+func (p *openAIProvider) applyThinkingAnthropic(body map[string]any) {
+	if p.thinkingEffort() == "off" {
+		return
+	}
+	if adaptiveModelRe.MatchString(p.cfg.Model) {
+		body["thinking"] = map[string]any{"type": "adaptive"}
+		return
+	}
+	budget := p.cfg.ThinkingBudget
+	if budget <= 0 {
+		budget = 8000
+	}
+	body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
+}
+
+func (p *openAIProvider) applyThinkingGemini(body map[string]any) {
+	effort := p.thinkingEffort()
+	tc := map[string]any{"includeThoughts": effort != "off"}
+	if effort != "off" {
+		if strings.Contains(strings.ToLower(p.cfg.Model), "gemini-3") {
+			level := effort
+			if level != "low" && level != "medium" && level != "high" {
+				level = "high"
+			}
+			tc["thinkingLevel"] = level
+		} else {
+			budget := p.cfg.ThinkingBudget
+			if budget <= 0 {
+				budget = 8192
+			}
+			tc["thinkingBudget"] = budget
+		}
+	}
+	body["thinkingConfig"] = tc
+}
+
+func (p *openAIProvider) applyThinkingResponses(body map[string]any) {
+	if p.thinkingEffort() == "off" {
+		return
+	}
+	body["reasoning"] = map[string]any{"effort": p.thinkingEffort(), "summary": "auto"}
+}
+
+// ---------- 采样参数优先级 ----------
+
+// resolveMaxTokens 优先级：req.MaxTokens > cfg.MaxTokens > 协议默认。
+func (p *openAIProvider) resolveMaxTokens(req ChatRequest, def int) int {
+	if req.MaxTokens > 0 {
+		return req.MaxTokens
+	}
+	if p.cfg.MaxTokens > 0 {
+		return p.cfg.MaxTokens
+	}
+	return def
+}
+
+// resolveTemperature 优先级：req.Temperature > cfg.Temperature。
+func (p *openAIProvider) resolveTemperature(req ChatRequest) float32 {
+	if req.Temperature > 0 {
+		return req.Temperature
+	}
+	return p.cfg.Temperature
 }
 
 // ---------- 底层 JSON 类型 ----------

--- a/internal/agent/provider/provider_presets.go
+++ b/internal/agent/provider/provider_presets.go
@@ -1,0 +1,119 @@
+package provider
+
+// ---------- 国产厂商协议能力预设表（§5.2） ----------
+// 官方文档实证（2026-08-06）。前端据此渲染"厂商 → 协议下拉"，选中后自动预填
+// base URL / 认证头 / api_mode，用户可再手动覆盖（url_editable=true）。
+
+// ProviderProtocol 国产厂商预设中的单个协议能力。
+type ProviderProtocol struct {
+	APIMode    APIMode // chat_completions | anthropic_messages | openai_responses
+	BaseURL    string  // 该协议下的 base URL（URLMode=auto 时追加协议后缀）
+	AuthHeader string  // ""=协议默认；国产 anthropic 端点认证头差异见下表
+	Note       string  // 覆盖范围限制（订阅 / 版本 / 模型），前端展示警告
+}
+
+// ProviderPreset 国产厂商硬编码预设。
+type ProviderPreset struct {
+	Key       string
+	Name      string
+	Protocols []ProviderProtocol // 用户可选的协议列表（硬编码，前端据此渲染下拉）
+}
+
+// providerPresets 国产厂商协议能力预设表。
+var providerPresets = map[string]ProviderPreset{
+	"deepseek": {
+		Key: "deepseek", Name: "DeepSeek",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.deepseek.com", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.deepseek.com/anthropic", AuthHeader: "x-api-key"},
+			{APIMode: APIModeOpenAIResponses, BaseURL: "https://api.deepseek.com", AuthHeader: "bearer", Note: "仅 deepseek-v4-flash 支持；无后续状态（previous_response_id/store 不支持）"},
+		},
+	},
+	"zhipu": {
+		Key: "zhipu", Name: "智谱 Z.AI",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://open.bigmodel.cn/api/paas/v4", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://open.bigmodel.cn/api/anthropic", AuthHeader: "x-api-key"},
+		},
+	},
+	"kimi": {
+		Key: "kimi", Name: "Moonshot Kimi",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.moonshot.cn/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.moonshot.cn/anthropic", AuthHeader: "bearer"},
+		},
+	},
+	"alibaba": {
+		Key: "alibaba", Name: "阿里百炼",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://dashscope.aliyuncs.com/apps/anthropic", AuthHeader: "x-api-key"},
+		},
+	},
+	"volcengine": {
+		Key: "volcengine", Name: "火山方舟",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://ark.cn-beijing.volces.com/api/v3", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://ark.cn-beijing.volces.com/api/v3/anthropic", AuthHeader: "bearer", Note: "需 Coding Plan 订阅"},
+			{APIMode: APIModeOpenAIResponses, BaseURL: "https://ark.cn-beijing.volces.com/api/v3", AuthHeader: "bearer", Note: "250615+ 新版模型默认支持（doubao-1-5-pro-32k-character-250715 例外）"},
+		},
+	},
+	"minimax": {
+		Key: "minimax", Name: "MiniMax",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.minimaxi.com/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.minimaxi.com/anthropic", AuthHeader: "bearer", Note: "仅 M 系列支持"},
+		},
+	},
+	"xiaomi": {
+		Key: "xiaomi", Name: "小米 MiMo",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.xiaomimimo.com/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.xiaomimimo.com/anthropic", AuthHeader: "api-key"},
+		},
+	},
+	"stepfun": {
+		Key: "stepfun", Name: "阶跃星辰",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.stepfun.com/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.stepfun.com/step_plan", AuthHeader: "bearer", Note: "需 Step Plan 订阅"},
+		},
+	},
+	"tencent": {
+		Key: "tencent", Name: "腾讯混元",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.hunyuan.cloud.tencent.com/v1", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.hunyuan.cloud.tencent.com/anthropic", AuthHeader: "x-api-key"},
+		},
+	},
+	"baidu": {
+		Key: "baidu", Name: "百度千帆",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://qianfan.baidubce.com/v2", AuthHeader: "bearer"},
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://qianfan.baidubce.com/anthropic", AuthHeader: "x-api-key"},
+		},
+	},
+	"siliconflow": {
+		Key: "siliconflow", Name: "硅基流动",
+		Protocols: []ProviderProtocol{
+			{APIMode: APIModeChatCompletions, BaseURL: "https://api.siliconflow.cn/v1", AuthHeader: "bearer"},
+			// base 已含 /v1，URLMode=auto 会追加 /messages
+			{APIMode: APIModeAnthropicMessages, BaseURL: "https://api.siliconflow.cn/v1", AuthHeader: "bearer"},
+		},
+	},
+}
+
+// GetProviderPreset 返回指定厂商的协议预设。
+func GetProviderPreset(key string) (ProviderPreset, bool) {
+	p, ok := providerPresets[normalizeProviderKey(key)]
+	return p, ok
+}
+
+// ListProviderPresets 返回全部厂商预设（供前端渲染）。
+func ListProviderPresets() []ProviderPreset {
+	list := make([]ProviderPreset, 0, len(providerPresets))
+	for _, p := range providerPresets {
+		list = append(list, p)
+	}
+	return list
+}

--- a/internal/agent/provider/provider_test.go
+++ b/internal/agent/provider/provider_test.go
@@ -1,0 +1,299 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------- URL 规则（§5.3） ----------
+
+func TestEndpointURL(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ProviderConfig
+		want string
+	}{
+		{"base chat_completions", ProviderConfig{Endpoint: "https://api.deepseek.com"}, "https://api.deepseek.com/chat/completions"},
+		{"base with /v1", ProviderConfig{Endpoint: "https://api.openai.com/v1"}, "https://api.openai.com/v1/chat/completions"},
+		{"full url detected", ProviderConfig{Endpoint: "https://openwebui.local/openai/v1/chat/completions"}, "https://openwebui.local/openai/v1/chat/completions"},
+		{"full url case-insensitive suffix", ProviderConfig{Endpoint: "https://x.com/openai/v1/Chat/Completions"}, "https://x.com/openai/v1/Chat/Completions"},
+		{"trailing slash trimmed", ProviderConfig{Endpoint: "https://api.deepseek.com/"}, "https://api.deepseek.com/chat/completions"},
+		{"anthropic base", ProviderConfig{APIMode: APIModeAnthropicMessages, Endpoint: "https://api.anthropic.com"}, "https://api.anthropic.com/messages"},
+		{"anthropic full url", ProviderConfig{APIMode: APIModeAnthropicMessages, Endpoint: "https://api.deepseek.com/anthropic"}, "https://api.deepseek.com/anthropic/messages"},
+		{"responses base", ProviderConfig{APIMode: APIModeOpenAIResponses, Endpoint: "https://api.deepseek.com"}, "https://api.deepseek.com/responses"},
+		{"gemini model path", ProviderConfig{APIMode: APIModeGeminiNative, Endpoint: "https://generativelanguage.googleapis.com/v1beta", Model: "gemini-3-flash"}, "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent"},
+		{"gemini full url", ProviderConfig{APIMode: APIModeGeminiNative, Endpoint: "https://x.com/models/gemini-3-flash:generateContent", Model: "gemini-3-flash"}, "https://x.com/models/gemini-3-flash:generateContent"},
+		{"exact mode raw", ProviderConfig{URLMode: "exact", Endpoint: "https://custom.io/openai/v1/chat/completions"}, "https://custom.io/openai/v1/chat/completions"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := NewProvider(c.cfg).(*openAIProvider)
+			if got := p.endpointURL(); got != c.want {
+				t.Errorf("endpointURL() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// ---------- 协议请求体快照（§7.2） ----------
+
+func TestBuildRequestChatCompletions(t *testing.T) {
+	p := NewProvider(ProviderConfig{
+		Model: "deepseek-v4-pro", Temperature: 0.7,
+		ProviderKey: "deepseek", ThinkingEffort: "high",
+	}).(*openAIProvider)
+	req := ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "system", Content: "你是助手"},
+			{Role: "user", Content: "你好"},
+		},
+		MaxTokens: 1000,
+		Tools: []ToolDef{
+			{Type: "function", Function: ToolDefFunc{Name: "get_weather", Description: "天气", Parameters: json.RawMessage(`{}`)}},
+		},
+	}
+	body, err := p.buildRequest(req, false)
+	if err != nil {
+		t.Fatalf("buildRequest err: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal err: %v", err)
+	}
+	if m["model"] != "deepseek-v4-pro" {
+		t.Errorf("model = %v", m["model"])
+	}
+	if m["max_tokens"] != float64(1000) {
+		t.Errorf("max_tokens = %v", m["max_tokens"])
+	}
+	// deepseek thinking_object + v4 reasoning_effort
+	th, ok := m["thinking"].(map[string]any)
+	if !ok || th["type"] != "enabled" {
+		t.Errorf("thinking = %v", m["thinking"])
+	}
+	if m["reasoning_effort"] != "high" {
+		t.Errorf("reasoning_effort = %v", m["reasoning_effort"])
+	}
+	if _, ok := m["tools"].([]any); !ok {
+		t.Errorf("tools missing")
+	}
+	if m["stream"] != nil {
+		t.Errorf("stream should be absent for non-stream")
+	}
+}
+
+// ---------- 响应解析（§7.3） ----------
+
+func TestParseAnthropic(t *testing.T) {
+	p := NewProvider(ProviderConfig{APIMode: APIModeAnthropicMessages}).(*openAIProvider)
+	body := `{"content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}],"usage":{"input_tokens":10,"output_tokens":5},"stop_reason":"end_turn"}`
+	resp, err := p.parseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("parse err: %v", err)
+	}
+	if resp.Message.Content != "hello world" {
+		t.Errorf("content = %q", resp.Message.Content)
+	}
+	if resp.TokenUsage != 15 {
+		t.Errorf("token = %d", resp.TokenUsage)
+	}
+}
+
+func TestParseGemini(t *testing.T) {
+	p := NewProvider(ProviderConfig{APIMode: APIModeGeminiNative}).(*openAIProvider)
+	body := `{"candidates":[{"content":{"parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"totalTokenCount":7}}`
+	resp, err := p.parseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("parse err: %v", err)
+	}
+	if resp.Message.Content != "hi" {
+		t.Errorf("content = %q", resp.Message.Content)
+	}
+	if resp.TokenUsage != 7 {
+		t.Errorf("token = %d", resp.TokenUsage)
+	}
+}
+
+func TestParseResponses(t *testing.T) {
+	p := NewProvider(ProviderConfig{APIMode: APIModeOpenAIResponses}).(*openAIProvider)
+	body := `{"output":[{"content":[{"type":"output_text","text":"ok"}]}],"usage":{"total_tokens":3},"status":"completed"}`
+	resp, err := p.parseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("parse err: %v", err)
+	}
+	if resp.Message.Content != "ok" {
+		t.Errorf("content = %q", resp.Message.Content)
+	}
+}
+
+// ---------- thinking 矩阵（§5.5） ----------
+
+func TestThinkingMatrix(t *testing.T) {
+	cases := []struct {
+		name  string
+		cfg   ProviderConfig
+		check func(t *testing.T, m map[string]any)
+	}{
+		{"deepseek off", ProviderConfig{ProviderKey: "deepseek", ThinkingEffort: "off"}, func(t *testing.T, m map[string]any) {
+			if th := m["thinking"]; th == nil || th.(map[string]any)["type"] != "disabled" {
+				t.Errorf("thinking = %v", m["thinking"])
+			}
+		}},
+		{"alibaba enabled", ProviderConfig{ProviderKey: "alibaba", ThinkingEffort: "high"}, func(t *testing.T, m map[string]any) {
+			if m["enable_thinking"] != true {
+				t.Errorf("enable_thinking = %v", m["enable_thinking"])
+			}
+		}},
+		{"default reasoning_effort", ProviderConfig{ThinkingEffort: "medium"}, func(t *testing.T, m map[string]any) {
+			if m["reasoning_effort"] != "medium" {
+				t.Errorf("reasoning_effort = %v", m["reasoning_effort"])
+			}
+		}},
+		{"enable_thinking legacy maps to medium", ProviderConfig{EnableThinking: true}, func(t *testing.T, m map[string]any) {
+			if m["reasoning_effort"] != "medium" {
+				t.Errorf("reasoning_effort = %v", m["reasoning_effort"])
+			}
+		}},
+		{"anthropic adaptive", ProviderConfig{APIMode: APIModeAnthropicMessages, Model: "claude-opus-4-7", ThinkingEffort: "high"}, func(t *testing.T, m map[string]any) {
+			if th := m["thinking"]; th == nil || th.(map[string]any)["type"] != "adaptive" {
+				t.Errorf("thinking = %v", m["thinking"])
+			}
+		}},
+		{"anthropic budget", ProviderConfig{APIMode: APIModeAnthropicMessages, Model: "claude-haiku-4-5", ThinkingEffort: "high", ThinkingBudget: 5000}, func(t *testing.T, m map[string]any) {
+			th := m["thinking"].(map[string]any)
+			if th["type"] != "enabled" || th["budget_tokens"] != float64(5000) {
+				t.Errorf("thinking = %v", th)
+			}
+		}},
+		{"gemini 3 level", ProviderConfig{APIMode: APIModeGeminiNative, Model: "gemini-3-flash", ThinkingEffort: "high"}, func(t *testing.T, m map[string]any) {
+			tc := m["thinkingConfig"].(map[string]any)
+			if tc["includeThoughts"] != true || tc["thinkingLevel"] != "high" {
+				t.Errorf("thinkingConfig = %v", tc)
+			}
+		}},
+		{"responses reasoning", ProviderConfig{APIMode: APIModeOpenAIResponses, ThinkingEffort: "high"}, func(t *testing.T, m map[string]any) {
+			r := m["reasoning"].(map[string]any)
+			if r["effort"] != "high" {
+				t.Errorf("reasoning = %v", r)
+			}
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := NewProvider(c.cfg).(*openAIProvider)
+			body, err := p.buildRequest(ChatRequest{}, false)
+			if err != nil {
+				t.Fatalf("build err: %v", err)
+			}
+			var m map[string]any
+			if err := json.Unmarshal(body, &m); err != nil {
+				t.Fatalf("unmarshal err: %v", err)
+			}
+			c.check(t, m)
+		})
+	}
+}
+
+// ---------- 参数映射优先级（§5.4） ----------
+
+func TestParseChatCompletions(t *testing.T) {
+	p := NewProvider(ProviderConfig{}).(*openAIProvider)
+	body := `{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"total_tokens":4}}`
+	resp, err := p.parseChatCompletions([]byte(body))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Message.Content != "hi" || resp.TokenUsage != 4 {
+		t.Errorf("resp = %+v", resp)
+	}
+}
+
+func TestResolveMaxTokens(t *testing.T) {
+	p := NewProvider(ProviderConfig{MaxTokens: 2000}).(*openAIProvider)
+	if got := p.resolveMaxTokens(ChatRequest{}, 4096); got != 2000 {
+		t.Errorf("cfg priority got %d", got)
+	}
+	if got := p.resolveMaxTokens(ChatRequest{MaxTokens: 3000}, 4096); got != 3000 {
+		t.Errorf("req priority got %d", got)
+	}
+	if got := p.resolveMaxTokens(ChatRequest{}, 4096); got != 2000 {
+		t.Errorf("default got %d", got)
+	}
+}
+
+// ---------- 兼容性（§7.6） ----------
+
+func TestEmptyAPIModeIsChatCompletions(t *testing.T) {
+	p := NewProvider(ProviderConfig{Endpoint: "https://api.deepseek.com"}).(*openAIProvider)
+	if p.APIMode() != APIModeChatCompletions {
+		t.Errorf("api mode = %v", p.APIMode())
+	}
+	if got := p.endpointURL(); got != "https://api.deepseek.com/chat/completions" {
+		t.Errorf("endpoint = %q", got)
+	}
+}
+
+// ---------- 认证头（§5.2） ----------
+
+func TestSetHeaders(t *testing.T) {
+	p := NewProvider(ProviderConfig{APIMode: APIModeAnthropicMessages, Token: "tok", AuthHeader: "x-api-key"}).(*openAIProvider)
+	req := mustNewRequest(t, "https://x/messages")
+	p.setHeaders(req)
+	if req.Header.Get("x-api-key") != "tok" {
+		t.Errorf("x-api-key = %q", req.Header.Get("x-api-key"))
+	}
+	if req.Header.Get("anthropic-version") != "2023-06-01" {
+		t.Errorf("version = %q", req.Header.Get("anthropic-version"))
+	}
+}
+
+func TestSetHeadersGeminiDefault(t *testing.T) {
+	p := NewProvider(ProviderConfig{APIMode: APIModeGeminiNative, Token: "tok"}).(*openAIProvider)
+	req := mustNewRequest(t, "https://x/messages")
+	p.setHeaders(req)
+	if req.Header.Get("x-goog-api-key") != "tok" {
+		t.Errorf("gemini key = %q", req.Header.Get("x-goog-api-key"))
+	}
+}
+
+// ---------- 厂商预设 ----------
+
+func TestProviderPresets(t *testing.T) {
+	preset, ok := GetProviderPreset("deepseek")
+	if !ok {
+		t.Fatal("deepseek preset missing")
+	}
+	if len(preset.Protocols) != 3 {
+		t.Errorf("deepseek protocols = %d, want 3", len(preset.Protocols))
+	}
+	if preset.Protocols[1].APIMode != APIModeAnthropicMessages {
+		t.Errorf("proto[1] mode = %v", preset.Protocols[1].APIMode)
+	}
+}
+
+// ---------- 模型能力元数据（§5.7） ----------
+
+func TestGetModelCapability(t *testing.T) {
+	if c, ok := GetModelCapability("deepseek-v4-pro"); !ok || c.ContextWindow != 1000000 {
+		t.Errorf("deepseek-v4-pro capability = %+v, ok=%v", c, ok)
+	}
+	// 前缀匹配：快照版本回落基础规格
+	if c, ok := GetModelCapability("deepseek-v4-flash-0731"); !ok || c.ThinkingPattern != ThinkingPatternThinkingObject {
+		t.Errorf("deepseek-v4-flash-0731 capability = %+v, ok=%v", c, ok)
+	}
+	if _, ok := GetModelCapability("unknown-model-xyz"); ok {
+		t.Errorf("unknown model should not be found")
+	}
+}
+
+// ---------- helpers ----------
+
+func mustNewRequest(t *testing.T, url string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		t.Fatalf("request err: %v", err)
+	}
+	return r
+}

--- a/internal/agent/provider/root.go
+++ b/internal/agent/provider/root.go
@@ -3,7 +3,20 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
+
+	"JuanNiang-Neo/internal/core/models"
+)
+
+// APIMode 协议模式（与 MintWord apiMode 对齐）。
+type APIMode string
+
+const (
+	APIModeChatCompletions   APIMode = "chat_completions"
+	APIModeAnthropicMessages APIMode = "anthropic_messages"
+	APIModeOpenAIResponses   APIMode = "openai_responses"
+	APIModeGeminiNative      APIMode = "gemini_native"
 )
 
 // ModelType 模型类型枚举。
@@ -25,8 +38,74 @@ type ProviderConfig struct {
 	Token       string    `json:"token"`
 	Model       string    `json:"model"`
 	Temperature float32   `json:"temperature"`
-	// EnableThinking 模型思考开关：true 时请求携带 thinking/enable_thinking 扩展参数
+	// EnableThinking 模型思考开关（旧字段）：true 且 ThinkingEffort 为空时映射为 effort=medium
 	EnableThinking bool `json:"enable_thinking"`
+	// APIMode 协议模式：空 = chat_completions（存量兼容）
+	APIMode APIMode `json:"api_mode,omitempty"`
+	// ThinkingEffort 思考档位：off/low/medium/high（空 + EnableThinking=false = off）
+	ThinkingEffort string `json:"thinking_effort,omitempty"`
+	// ThinkingBudget anthropic/gemini 的 thinking 预算 token（0 = 协议默认）
+	ThinkingBudget    int      `json:"thinking_budget,omitempty"`
+	MaxTokens         int      `json:"max_tokens,omitempty"`
+	TopP              *float32 `json:"top_p,omitempty"`
+	TopK              *int     `json:"top_k,omitempty"`
+	FrequencyPenalty  *float32 `json:"frequency_penalty,omitempty"`
+	PresencePenalty   *float32 `json:"presence_penalty,omitempty"`
+	RepetitionPenalty *float32 `json:"repetition_penalty,omitempty"`
+	// ProviderKey 厂商分组（deepseek/kimi/zhipu/...），驱动 thinking 矩阵与认证头分派；空 = 按 Name 关键词匹配
+	ProviderKey string `json:"provider_key,omitempty"`
+	// AuthHeader 认证头：""|bearer|x-api-key|api-key（空 = 按协议默认）
+	AuthHeader string `json:"auth_header,omitempty"`
+	// URLMode URL 拼接：""|auto|exact（auto=base+协议后缀自动拼接；exact=完整端点原样使用）
+	URLMode string `json:"url_mode,omitempty"`
+}
+
+// apiMode 返回归一化后的协议模式（空 → chat_completions）。
+func (c *ProviderConfig) apiMode() APIMode {
+	if c.APIMode == "" {
+		return APIModeChatCompletions
+	}
+	return c.APIMode
+}
+
+// urlMode 返回归一化后的 URL 模式（空 → auto）。
+func (c *ProviderConfig) urlMode() string {
+	if c.URLMode == "" {
+		return "auto"
+	}
+	return c.URLMode
+}
+
+// ProviderConfigFromModel 把 GORM Provider 模型映射为运行时 ProviderConfig。
+// 供 service / agent 启动加载统一使用，避免新字段在多处遗漏。
+func ProviderConfigFromModel(m *models.Provider) ProviderConfig {
+	return ProviderConfig{
+		ID:                m.ID,
+		Type:              ModelType(m.Type),
+		Name:              m.Name,
+		Endpoint:          m.Endpoint,
+		Token:             m.Token,
+		Model:             m.Model,
+		Temperature:       m.Temperature,
+		EnableThinking:    m.EnableThinking,
+		APIMode:           APIMode(m.APIMode),
+		ThinkingEffort:    m.ThinkingEffort,
+		ThinkingBudget:    m.ThinkingBudget,
+		MaxTokens:         m.MaxTokens,
+		TopP:              m.TopP,
+		TopK:              m.TopK,
+		FrequencyPenalty:  m.FrequencyPenalty,
+		PresencePenalty:   m.PresencePenalty,
+		RepetitionPenalty: m.RepetitionPenalty,
+		ProviderKey:       m.ProviderKey,
+		AuthHeader:        m.AuthHeader,
+		URLMode:           m.URLMode,
+	}
+}
+
+// normalizeProviderKey 小写归一化厂商分组关键词。
+func normalizeProviderKey(key string) string {
+	return strings.ToLower(strings.TrimSpace(key))
 }
 
 // ---------- 请求/响应 ----------

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -66,9 +66,11 @@ func RegisterBuiltinTools(
 	getCurrentMsg func(ctx context.Context) *adapter.MessageEvent,
 	getRecentMsgs func(ctx context.Context, msgType string, targetID int64, limit int) ([]string, error),
 	listImages func(ctx context.Context, folder string, limit int) (string, error),
+	searchImages func(ctx context.Context, keyword string, limit int) (string, error),
 	listStickerTags func(ctx context.Context) (string, error),
 	listStickers func(ctx context.Context, tag string, page, pageSize int) (string, error),
 	searchStickers func(ctx context.Context, keyword string, limit int) (string, error),
+	searchKnowledge func(ctx context.Context, keyword string, limit int) (string, error),
 ) {
 	tools := []Tool{}
 
@@ -95,6 +97,31 @@ func RegisterBuiltinTools(
 				return "图床未初始化", nil
 			}
 			return listImages(ctx, p.Folder, p.Limit)
+		},
+	})
+
+	// search_images 图床按名称搜索：Agent 不知道图片 ID 时按图片展示名搜索，
+	// 拿到 ID 后可拼 [CQ:image,file=imgs://图片ID] 引用（发送层会自动转 base64）。
+	tools = append(tools, &onebotTool{
+		BaseTool: NewTool("", "search_images", "按图片展示名称模糊搜索图床中的图片（含 ID/名称/文件夹），用于按名找到图床图片后在消息中用 [CQ:image,file=imgs://图片ID] 引用；发图前先调用本工具获取图片 ID",
+			openai.FunctionParameters{
+				"type": "object",
+				"properties": map[string]any{
+					"keyword": map[string]any{"type": "string", "description": "图片名称关键词（匹配名称，如 猫/meme/表情）"},
+					"limit":   map[string]any{"type": "integer", "description": "返回条数上限（默认 20，最大 50）"},
+				},
+				"required": []string{"keyword"},
+			}, false, false),
+		executor: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var p struct {
+				Keyword string `json:"keyword"`
+				Limit   int    `json:"limit"`
+			}
+			_ = json.Unmarshal(args, &p)
+			if searchImages == nil {
+				return "图床未初始化", nil
+			}
+			return searchImages(ctx, p.Keyword, p.Limit)
 		},
 	})
 
@@ -217,6 +244,31 @@ func RegisterBuiltinTools(
 				return "表情包库未初始化", nil
 			}
 			return searchStickers(ctx, p.Keyword, p.Limit)
+		},
+	})
+
+	// search_knowledge 知识库主动检索：区别于对话前自动注入的 knowledge context，
+	// 让 Agent 在对话中按需查询知识库内容。
+	tools = append(tools, &onebotTool{
+		BaseTool: NewTool("", "search_knowledge", "按关键词主动检索知识库，返回相关知识内容。当你需要查阅团队/项目/领域的知识、术语、规则或资料时调用；对话开始时系统已自动注入过一些知识，但若需要更细或更多内容请主动调用本工具",
+			openai.FunctionParameters{
+				"type": "object",
+				"properties": map[string]any{
+					"keyword": map[string]any{"type": "string", "description": "检索关键词（匹配知识关键词或内容）"},
+					"limit":   map[string]any{"type": "integer", "description": "返回条数上限（默认 5，最大 20）"},
+				},
+				"required": []string{"keyword"},
+			}, true, false),
+		executor: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var p struct {
+				Keyword string `json:"keyword"`
+				Limit   int    `json:"limit"`
+			}
+			_ = json.Unmarshal(args, &p)
+			if searchKnowledge == nil {
+				return "知识库未初始化", nil
+			}
+			return searchKnowledge(ctx, p.Keyword, p.Limit)
 		},
 	})
 

--- a/internal/api/dto/request.go
+++ b/internal/api/dto/request.go
@@ -59,25 +59,49 @@ type UpdateAdapterConfigReq struct {
 }
 
 type AddProviderReq struct {
-	Name           string           `json:"name"`
-	Type           models.ModelType `json:"type"`
-	Endpoint       string           `json:"endpoint"`
-	Token          string           `json:"token"`
-	Model          string           `json:"model"`
-	Temperature    FlexFloat32      `json:"temperature"`
-	IsActive       bool             `json:"isActive"`
-	EnableThinking bool             `json:"enable_thinking"` // 模型思考开关
+	Name              string           `json:"name"`
+	Type              models.ModelType `json:"type"`
+	Endpoint          string           `json:"endpoint"`
+	Token             string           `json:"token"`
+	Model             string           `json:"model"`
+	Temperature       FlexFloat32      `json:"temperature"`
+	IsActive          bool             `json:"isActive"`
+	EnableThinking    bool             `json:"enable_thinking"` // 模型思考开关（旧字段）
+	APIMode           string           `json:"api_mode"`        // 协议模式：chat_completions/anthropic_messages/openai_responses/gemini_native
+	ThinkingEffort    string           `json:"thinking_effort"` // off/low/medium/high
+	ThinkingBudget    int              `json:"thinking_budget"`
+	MaxTokens         int              `json:"max_tokens"`
+	TopP              *FlexFloat32     `json:"top_p"`
+	TopK              *int             `json:"top_k"`
+	FrequencyPenalty  *FlexFloat32     `json:"frequency_penalty"`
+	PresencePenalty   *FlexFloat32     `json:"presence_penalty"`
+	RepetitionPenalty *FlexFloat32     `json:"repetition_penalty"`
+	ProviderKey       string           `json:"provider_key"`
+	AuthHeader        string           `json:"auth_header"`
+	URLMode           string           `json:"url_mode"`
 }
 
 type UpdateProviderReq struct {
-	Name           string           `json:"name"`
-	Type           models.ModelType `json:"type"`
-	Endpoint       string           `json:"endpoint"`
-	Token          string           `json:"token"`
-	Model          string           `json:"model"`
-	Temperature    FlexFloat32      `json:"temperature"`
-	IsActive       bool             `json:"isActive"`
-	EnableThinking bool             `json:"enable_thinking"` // 模型思考开关
+	Name              string           `json:"name"`
+	Type              models.ModelType `json:"type"`
+	Endpoint          string           `json:"endpoint"`
+	Token             string           `json:"token"`
+	Model             string           `json:"model"`
+	Temperature       FlexFloat32      `json:"temperature"`
+	IsActive          bool             `json:"isActive"`
+	EnableThinking    bool             `json:"enable_thinking"` // 模型思考开关（旧字段）
+	APIMode           string           `json:"api_mode"`
+	ThinkingEffort    string           `json:"thinking_effort"`
+	ThinkingBudget    int              `json:"thinking_budget"`
+	MaxTokens         int              `json:"max_tokens"`
+	TopP              *FlexFloat32     `json:"top_p"`
+	TopK              *int             `json:"top_k"`
+	FrequencyPenalty  *FlexFloat32     `json:"frequency_penalty"`
+	PresencePenalty   *FlexFloat32     `json:"presence_penalty"`
+	RepetitionPenalty *FlexFloat32     `json:"repetition_penalty"`
+	ProviderKey       string           `json:"provider_key"`
+	AuthHeader        string           `json:"auth_header"`
+	URLMode           string           `json:"url_mode"`
 }
 
 type ToggleProviderReq struct {

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -79,16 +79,43 @@ type AdapterConfig struct {
 }
 
 type ProviderResp struct {
-	ID             string           `json:"id"`
-	CreatedAt      time.Time        `json:"created_at"`
-	Name           string           `json:"name"`
-	Type           models.ModelType `json:"type"`
-	Endpoint       string           `json:"endpoint"`
-	Token          string           `json:"token"`
-	Model          string           `json:"model"`
-	Temperature    float32          `json:"temperature"`
-	IsActive       bool             `json:"is_active"`
-	EnableThinking bool             `json:"enable_thinking"` // 模型思考开关
+	ID                string           `json:"id"`
+	CreatedAt         time.Time        `json:"created_at"`
+	Name              string           `json:"name"`
+	Type              models.ModelType `json:"type"`
+	Endpoint          string           `json:"endpoint"`
+	Token             string           `json:"token"`
+	Model             string           `json:"model"`
+	Temperature       float32          `json:"temperature"`
+	IsActive          bool             `json:"is_active"`
+	EnableThinking    bool             `json:"enable_thinking"` // 模型思考开关（旧字段）
+	APIMode           string           `json:"api_mode"`        // 协议模式
+	ThinkingEffort    string           `json:"thinking_effort"`
+	ThinkingBudget    int              `json:"thinking_budget"`
+	MaxTokens         int              `json:"max_tokens"`
+	TopP              *float32         `json:"top_p"`
+	TopK              *int             `json:"top_k"`
+	FrequencyPenalty  *float32         `json:"frequency_penalty"`
+	PresencePenalty   *float32         `json:"presence_penalty"`
+	RepetitionPenalty *float32         `json:"repetition_penalty"`
+	ProviderKey       string           `json:"provider_key"`
+	AuthHeader        string           `json:"auth_header"`
+	URLMode           string           `json:"url_mode"`
+}
+
+// ProviderPresetResp 国产厂商协议能力预设（前端渲染协议下拉）。
+type ProviderPresetResp struct {
+	Key       string                 `json:"key"`
+	Name      string                 `json:"name"`
+	Protocols []ProviderProtocolResp `json:"protocols"`
+}
+
+// ProviderProtocolResp 单个协议能力。
+type ProviderProtocolResp struct {
+	APIMode    string `json:"api_mode"`
+	BaseURL    string `json:"base_url"`
+	AuthHeader string `json:"auth_header"`
+	Note       string `json:"note,omitempty"`
 }
 
 type MCPServerResp struct {

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -111,11 +111,18 @@ type ProviderPresetResp struct {
 }
 
 // ProviderProtocolResp 单个协议能力。
+// ProviderProtocolResp 协议能力预设（前端渲染协议下拉）。
 type ProviderProtocolResp struct {
 	APIMode    string `json:"api_mode"`
 	BaseURL    string `json:"base_url"`
 	AuthHeader string `json:"auth_header"`
 	Note       string `json:"note,omitempty"`
+}
+
+// TestProviderResp 连接测试结果。
+type TestProviderResp struct {
+	Ok      bool   `json:"ok"`
+	Message string `json:"message"` // 成功=模型回复；失败=错误详情
 }
 
 type MCPServerResp struct {

--- a/internal/api/dto/transfer.go
+++ b/internal/api/dto/transfer.go
@@ -10,19 +10,63 @@ func RawProviderList2Resp(raw []models.Provider) []ProviderResp {
 	res := make([]ProviderResp, len(raw))
 
 	for i, item := range raw {
-		res[i].ID = item.ID
-		res[i].CreatedAt = item.CreatedAt
-		res[i].Name = item.Name
-		res[i].Type = item.Type
-		res[i].Endpoint = item.Endpoint
-		res[i].Token = item.Token
-		res[i].Model = item.Model
-		res[i].Temperature = item.Temperature
-		res[i].IsActive = item.IsActive
-		res[i].EnableThinking = item.EnableThinking
+		res[i] = RawProvider2Resp(&item)
 	}
 
 	return res
+}
+
+// RawProvider2Resp 单个 Provider → 响应 DTO。
+func RawProvider2Resp(raw *models.Provider) ProviderResp {
+	return ProviderResp{
+		ID:                raw.ID,
+		CreatedAt:         raw.CreatedAt,
+		Name:              raw.Name,
+		Type:              raw.Type,
+		Endpoint:          raw.Endpoint,
+		Token:             raw.Token,
+		Model:             raw.Model,
+		Temperature:       raw.Temperature,
+		IsActive:          raw.IsActive,
+		EnableThinking:    raw.EnableThinking,
+		APIMode:           raw.APIMode,
+		ThinkingEffort:    raw.ThinkingEffort,
+		ThinkingBudget:    raw.ThinkingBudget,
+		MaxTokens:         raw.MaxTokens,
+		TopP:              raw.TopP,
+		TopK:              raw.TopK,
+		FrequencyPenalty:  raw.FrequencyPenalty,
+		PresencePenalty:   raw.PresencePenalty,
+		RepetitionPenalty: raw.RepetitionPenalty,
+		ProviderKey:       raw.ProviderKey,
+		AuthHeader:        raw.AuthHeader,
+		URLMode:           raw.URLMode,
+	}
+}
+
+// flexFloat32Ptr 把 *FlexFloat32 转为 *float32（nil 透传）。
+func flexFloat32Ptr(p *FlexFloat32) *float32 {
+	if p == nil {
+		return nil
+	}
+	v := float32(*p)
+	return &v
+}
+
+// ApplyProviderFields 把请求中共有的扩展字段写入 models.Provider（Add/Update 复用）。
+func ApplyProviderFields(m *models.Provider, apiMode, thinkingEffort string, thinkingBudget, maxTokens int, topP *FlexFloat32, topK *int, freqPenalty, presencePenalty, repetitionPenalty *FlexFloat32, providerKey, authHeader, urlMode string) {
+	m.APIMode = apiMode
+	m.ThinkingEffort = thinkingEffort
+	m.ThinkingBudget = thinkingBudget
+	m.MaxTokens = maxTokens
+	m.TopP = flexFloat32Ptr(topP)
+	m.TopK = topK
+	m.FrequencyPenalty = flexFloat32Ptr(freqPenalty)
+	m.PresencePenalty = flexFloat32Ptr(presencePenalty)
+	m.RepetitionPenalty = flexFloat32Ptr(repetitionPenalty)
+	m.ProviderKey = providerKey
+	m.AuthHeader = authHeader
+	m.URLMode = urlMode
 }
 
 func RawMCPServer2Resp(raw *models.MCPServer) MCPServerResp {

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -32,6 +32,7 @@ func RegisterRoutes(h *server.Hertz, svc *service.Service) {
 	api.PUT("/providers/:id", auth, svc.UpdateProvider)
 	api.DELETE("/providers/:id", auth, svc.DeleteProvider)
 	api.PUT("/providers/:id/toggle", auth, svc.ToggleProvider)
+	api.POST("/providers/test", auth, svc.TestProvider)
 
 	// MCP
 	api.GET("/mcp", auth, svc.ListMCPServers)

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -26,6 +26,7 @@ func RegisterRoutes(h *server.Hertz, svc *service.Service) {
 
 	// Providers
 	api.GET("/providers", auth, svc.ListProviders)
+	api.GET("/providers/presets", auth, svc.ListProviderPresets)
 	api.GET("/providers/:id", auth, svc.GetProvider)
 	api.POST("/providers", auth, svc.AddProvider)
 	api.PUT("/providers/:id", auth, svc.UpdateProvider)

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -1704,7 +1704,7 @@ func (s *Service) UpdateShortTermMemoryConfig(ctx context.Context, c *app.Reques
 
 	// 运行时同步
 	if s.MemoryGroup != nil {
-		s.MemoryGroup.UpdateShortTermConfig(memory.ShortTermMemoryConfig{
+		s.MemoryGroup.UpdateShortTermConfig(chatAreaID, memory.ShortTermMemoryConfig{
 			WindowSize:  int64(data.WindowSize),
 			AutoCompact: data.AutoCompact,
 		})

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -396,6 +396,45 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, nil))
 }
 
+// TestProvider 用请求中的配置构建临时 Provider 并发送一条最小探测消息，
+// 校验 API 地址 / Token / 模型名是否可用（不落库、不影响运行时）。
+func (s *Service) TestProvider(ctx context.Context, c *app.RequestContext) {
+	var data dto.AddProviderReq
+	if err := c.BindJSON(&data); err != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.BindJSONErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+	if s.ProviderGroup == nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, dto.TestProviderResp{Ok: false, Message: "Provider 运行时未初始化"}))
+		return
+	}
+
+	m := &models.Provider{
+		Name:           data.Name,
+		Type:           data.Type,
+		Endpoint:       data.Endpoint,
+		Token:          data.Token,
+		Model:          data.Model,
+		Temperature:    float32(data.Temperature),
+		EnableThinking: data.EnableThinking,
+	}
+	dto.ApplyProviderFields(m, data.APIMode, data.ThinkingEffort, data.ThinkingBudget, data.MaxTokens, data.TopP, data.TopK, data.FrequencyPenalty, data.PresencePenalty, data.RepetitionPenalty, data.ProviderKey, data.AuthHeader, data.URLMode)
+
+	p := provider.NewProvider(provider.ProviderConfigFromModel(m))
+	testCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	resp, err := p.Chat(testCtx, provider.ChatRequest{
+		Messages:  []provider.ChatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: 16,
+	})
+	if err != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, dto.TestProviderResp{Ok: false, Message: err.Error()}))
+		return
+	}
+	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, dto.TestProviderResp{Ok: true, Message: resp.Message.Content}))
+}
+
 func (s *Service) ListMCPServers(ctx context.Context, c *app.RequestContext) {
 	list, err := s.DAO.MCPServer.List(ctx)
 	if err != nil {

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -188,6 +188,25 @@ func (s *Service) ListProviders(ctx context.Context, c *app.RequestContext) {
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, list))
 }
 
+// ListProviderPresets 返回国产厂商协议能力预设表（供前端渲染协议下拉）。
+func (s *Service) ListProviderPresets(ctx context.Context, c *app.RequestContext) {
+	presets := provider.ListProviderPresets()
+	resp := make([]dto.ProviderPresetResp, 0, len(presets))
+	for _, p := range presets {
+		rp := dto.ProviderPresetResp{Key: p.Key, Name: p.Name}
+		for _, proto := range p.Protocols {
+			rp.Protocols = append(rp.Protocols, dto.ProviderProtocolResp{
+				APIMode:    string(proto.APIMode),
+				BaseURL:    proto.BaseURL,
+				AuthHeader: proto.AuthHeader,
+				Note:       proto.Note,
+			})
+		}
+		resp = append(resp, rp)
+	}
+	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, resp))
+}
+
 func (s *Service) GetProvider(ctx context.Context, c *app.RequestContext) {
 	raw, err := s.DAO.Provider.GetByID(ctx, c.Param("id"))
 
@@ -196,18 +215,7 @@ func (s *Service) GetProvider(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	data := dto.ProviderResp{
-		ID:             raw.ID,
-		CreatedAt:      raw.CreatedAt,
-		Name:           raw.Name,
-		Type:           raw.Type,
-		Endpoint:       raw.Endpoint,
-		Token:          raw.Token,
-		Model:          raw.Model,
-		Temperature:    raw.Temperature,
-		IsActive:       raw.IsActive,
-		EnableThinking: raw.EnableThinking,
-	}
+	data := dto.RawProvider2Resp(raw)
 
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, data))
 }
@@ -232,6 +240,7 @@ func (s *Service) AddProvider(ctx context.Context, c *app.RequestContext) {
 		IsActive:       data.IsActive,
 		EnableThinking: data.EnableThinking,
 	}
+	dto.ApplyProviderFields(&providerConfig, data.APIMode, data.ThinkingEffort, data.ThinkingBudget, data.MaxTokens, data.TopP, data.TopK, data.FrequencyPenalty, data.PresencePenalty, data.RepetitionPenalty, data.ProviderKey, data.AuthHeader, data.URLMode)
 
 	// 同类型只能有一个 Active：激活前先停用同类型其他 Provider
 	if data.IsActive {
@@ -254,16 +263,7 @@ func (s *Service) AddProvider(ctx context.Context, c *app.RequestContext) {
 				s.ProviderGroup.DelProvider(p.ID())
 			}
 		}
-		s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfig{
-			ID:             id,
-			Name:           data.Name,
-			Type:           provType,
-			Endpoint:       data.Endpoint,
-			Token:          data.Token,
-			Model:          data.Model,
-			Temperature:    float32(data.Temperature),
-			EnableThinking: data.EnableThinking,
-		}))
+		s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfigFromModel(&providerConfig)))
 	}
 
 	// Provider 变更影响 Eino Agent 的 model adapter（构建时持有实例引用），必须重建
@@ -301,18 +301,10 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 		IsActive:       data.IsActive,
 		EnableThinking: data.EnableThinking,
 	}
+	dto.ApplyProviderFields(&providerConfig, data.APIMode, data.ThinkingEffort, data.ThinkingBudget, data.MaxTokens, data.TopP, data.TopK, data.FrequencyPenalty, data.PresencePenalty, data.RepetitionPenalty, data.ProviderKey, data.AuthHeader, data.URLMode)
 
 	provType := provider.ModelType(data.Type)
-	providerConfig_ := provider.ProviderConfig{
-		ID:             id,
-		Name:           data.Name,
-		Type:           provType,
-		Endpoint:       data.Endpoint,
-		Token:          data.Token,
-		Model:          data.Model,
-		Temperature:    float32(data.Temperature),
-		EnableThinking: data.EnableThinking,
-	}
+	providerConfig_ := provider.ProviderConfigFromModel(&providerConfig)
 
 	// 运行时同步：先移除同类型旧的，再同步新配置
 	if s.ProviderGroup != nil {
@@ -385,16 +377,7 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 					s.ProviderGroup.DelProvider(p.ID())
 				}
 			}
-			s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfig{
-				ID:             id,
-				Name:           raw.Name,
-				Type:           provType,
-				Endpoint:       raw.Endpoint,
-				Token:          raw.Token,
-				Model:          raw.Model,
-				Temperature:    raw.Temperature,
-				EnableThinking: raw.EnableThinking,
-			}))
+			s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfigFromModel(raw)))
 		}
 	} else {
 		if s.ProviderGroup != nil {

--- a/internal/core/dao/imageDao.go
+++ b/internal/core/dao/imageDao.go
@@ -2,10 +2,12 @@ package dao
 
 import (
 	"context"
+	"strings"
 
 	"JuanNiang-Neo/internal/core/models"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // ImageDAO 图床图片 + 虚拟文件夹。
@@ -41,6 +43,26 @@ func (d *ImageDAO) List(ctx context.Context, folder string, limit, offset int) (
 	var list []models.ImageAsset
 	q := d.db.WithContext(ctx).Where("folder = ?", normalizeFolder(folder))
 	err := q.Order("created_at DESC").Limit(limit).Offset(offset).Find(&list).Error
+	return list, err
+}
+
+// SearchByName 按图片展示名称模糊匹配（供 Agent search_images 工具使用）。
+// 命中条件：name ILIKE '%keyword%'；结果按名称匹配度（前缀优先）再按创建时间倒序。
+func (d *ImageDAO) SearchByName(ctx context.Context, keyword string, limit int) ([]models.ImageAsset, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return nil, nil
+	}
+	var list []models.ImageAsset
+	err := d.db.WithContext(ctx).
+		Where("name ILIKE ?", "%"+keyword+"%").
+		Order(clause.Expr{SQL: "CASE WHEN name ILIKE ? THEN 0 ELSE 1 END", Vars: []interface{}{keyword + "%"}}).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&list).Error
 	return list, err
 }
 

--- a/internal/core/dao/shortTermMemDao.go
+++ b/internal/core/dao/shortTermMemDao.go
@@ -23,9 +23,10 @@ func (d *ShortTermMemoryDAO) GetOrCreate(ctx context.Context, chatAreaID string)
 	}
 
 	m = models.ShortTermMemory{
-		ID:         newUUID(),
-		ChatAreaID: chatAreaID,
-		WindowSize: 20,
+		ID:          newUUID(),
+		ChatAreaID:  chatAreaID,
+		WindowSize:  100,
+		AutoCompact: true,
 	}
 	if err := d.db.WithContext(ctx).Create(&m).Error; err != nil {
 		return nil, err

--- a/internal/core/dao/stickerDao.go
+++ b/internal/core/dao/stickerDao.go
@@ -65,7 +65,7 @@ func (d *StickerDAO) List(ctx context.Context, tag, keyword string, limit, offse
 	}
 	if keyword != "" {
 		like := "%" + keyword + "%"
-		q = q.Where("name ILIKE ? OR desc ILIKE ?", like, like)
+		q = q.Where("name ILIKE ? OR \"desc\" ILIKE ?", like, like)
 	}
 	err := q.Order("created_at DESC").Limit(limit).Offset(offset).Find(&list).Error
 	return list, err
@@ -80,7 +80,7 @@ func (d *StickerDAO) Count(ctx context.Context, tag, keyword string) (int64, err
 	}
 	if keyword != "" {
 		like := "%" + keyword + "%"
-		q = q.Where("name ILIKE ? OR desc ILIKE ?", like, like)
+		q = q.Where("name ILIKE ? OR \"desc\" ILIKE ?", like, like)
 	}
 	err := q.Count(&n).Error
 	return n, err

--- a/internal/core/dao/stickerDao.go
+++ b/internal/core/dao/stickerDao.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"encoding/json"
 
 	"JuanNiang-Neo/internal/core/models"
 
@@ -47,8 +48,9 @@ func (d *StickerDAO) GetByID(ctx context.Context, id string) (*models.Sticker, e
 	return &s, nil
 }
 
-// List 分页列出表情，支持按标签过滤（tags jsonb ? 操作符）与名称/简介模糊匹配。
-// 注意：PG 的 jsonb "?" 操作符在 GORM 中必须写成 "??"（GORM 用 ?? 转义字面 ?）。
+// List 分页列出表情，支持按标签过滤（tags jsonb @> 包含操作符）与名称/简介模糊匹配。
+// 注意：PG 的 jsonb "?" 操作符在 GORM v1.31 中会因 "?" 被当作占位符而报错，
+// 故改用 "@>"（包含）并以 JSON 数组参数传入，避免转义问题。
 func (d *StickerDAO) List(ctx context.Context, tag, keyword string, limit, offset int) ([]models.Sticker, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
@@ -59,7 +61,7 @@ func (d *StickerDAO) List(ctx context.Context, tag, keyword string, limit, offse
 	var list []models.Sticker
 	q := d.db.WithContext(ctx).Model(&models.Sticker{})
 	if tag != "" {
-		q = q.Where("tags ?? ?", tag)
+		q = q.Where("tags @> ?", tagJSONArray(tag))
 	}
 	if keyword != "" {
 		like := "%" + keyword + "%"
@@ -74,7 +76,7 @@ func (d *StickerDAO) Count(ctx context.Context, tag, keyword string) (int64, err
 	var n int64
 	q := d.db.WithContext(ctx).Model(&models.Sticker{})
 	if tag != "" {
-		q = q.Where("tags ?? ?", tag)
+		q = q.Where("tags @> ?", tagJSONArray(tag))
 	}
 	if keyword != "" {
 		like := "%" + keyword + "%"
@@ -82,6 +84,15 @@ func (d *StickerDAO) Count(ctx context.Context, tag, keyword string) (int64, err
 	}
 	err := q.Count(&n).Error
 	return n, err
+}
+
+// tagJSONArray 把单个标签名包装为 JSON 数组字符串（用于 jsonb @> 包含查询）。
+func tagJSONArray(tag string) string {
+	b, err := json.Marshal([]string{tag})
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
 }
 
 func (d *StickerDAO) Update(ctx context.Context, s *models.Sticker) error {

--- a/internal/core/models/provider.go
+++ b/internal/core/models/provider.go
@@ -24,12 +24,32 @@ type Provider struct {
 	Token       string    `gorm:"not null"`
 	Model       string    `gorm:"not null"`
 	Temperature float32   `gorm:"default:0.7"`
-	// EnableThinking 模型思考开关：请求体携带 thinking/enable_thinking 扩展参数
+	// EnableThinking 模型思考开关（旧字段）：请求体携带 thinking/enable_thinking 扩展参数
 	EnableThinking bool `gorm:"default:false"`
-	IsActive       bool `gorm:"default:true;index"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	DeletedAt      gorm.DeletedAt `gorm:"index"`
+	// APIMode 协议模式：chat_completions / anthropic_messages / openai_responses / gemini_native；空 = chat_completions
+	APIMode string `gorm:"default:''"`
+	// ThinkingEffort 思考档位：off/low/medium/high
+	ThinkingEffort string `gorm:"default:''"`
+	// ThinkingBudget anthropic/gemini 思考预算 token（0 = 协议默认）
+	ThinkingBudget int `gorm:"default:0"`
+	// MaxTokens 生成上限 token（0 = 协议默认）
+	MaxTokens int `gorm:"default:0"`
+	// TopP / TopK / 惩罚参数（指针：nil = 不携带）
+	TopP              *float32 `gorm:"default:null"`
+	TopK              *int     `gorm:"default:null"`
+	FrequencyPenalty  *float32 `gorm:"default:null"`
+	PresencePenalty   *float32 `gorm:"default:null"`
+	RepetitionPenalty *float32 `gorm:"default:null"`
+	// ProviderKey 厂商分组（deepseek/kimi/zhipu/...），驱动 thinking 矩阵；空 = 按 Name 关键词匹配
+	ProviderKey string `gorm:"default:''"`
+	// AuthHeader 认证头：""|bearer|x-api-key|api-key
+	AuthHeader string `gorm:"default:''"`
+	// URLMode URL 拼接：""|auto|exact
+	URLMode   string `gorm:"default:''"`
+	IsActive  bool   `gorm:"default:true;index"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 func (Provider) TableName() string {

--- a/internal/core/models/shortTermMem.go
+++ b/internal/core/models/shortTermMem.go
@@ -12,8 +12,8 @@ type ShortTermMemory struct {
 	ID          string   `gorm:"primaryKey;type:uuid"`
 	ChatAreaID  string   `gorm:"uniqueIndex;not null"`
 	ChatArea    ChatArea `gorm:"foreignKey:ChatAreaID"`
-	WindowSize  int      `gorm:"default:20"`
-	AutoCompact bool     `gorm:"default:false"`
+	WindowSize  int      `gorm:"default:100"`
+	AutoCompact bool     `gorm:"default:true"`
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -77,7 +77,10 @@ export const providerApi = {
   update: (id: string, data: AddProviderReq) => client.put(`/providers/${id}`, data),
   delete: (id: string) => client.delete(`/providers/${id}`),
   toggle: (id: string, is_active: boolean) => client.put(`/providers/${id}/toggle`, { is_active }),
+  test: (data: AddProviderReq) => client.post('/providers/test', data),
 }
+
+export interface TestProviderResp { ok: boolean; message: string }
 
 export const providerPresetsApi = {
   list: () => client.get('/providers/presets'),

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -9,8 +9,10 @@ export interface AdapterConnDetail { id: number; ip: string; self_id: number }
 export interface AdapterStatus { running: boolean; listen_addr: string; self_id: number; conn_count: number; conn_ids: number[]; conns: AdapterConnDetail[] }
 export interface UpdateAdapterConfigReq { addr: string; port: number; token: string; admin_qq_numbers: string[]; enabled: boolean }
 
-export interface ProviderResp { id: string; created_at: string; name: string; type: string; endpoint: string; token: string; model: string; temperature: number; is_active: boolean; enable_thinking: boolean }
-export interface AddProviderReq { name: string; type: string; endpoint: string; token: string; model: string; temperature?: number; isActive: boolean; enable_thinking: boolean }
+export interface ProviderResp { id: string; created_at: string; name: string; type: string; endpoint: string; token: string; model: string; temperature: number; is_active: boolean; enable_thinking: boolean; api_mode: string; thinking_effort: string; thinking_budget: number; max_tokens: number; top_p: number | null; top_k: number | null; frequency_penalty: number | null; presence_penalty: number | null; repetition_penalty: number | null; provider_key: string; auth_header: string; url_mode: string }
+export interface ProviderPresetProtocol { api_mode: string; base_url: string; auth_header: string; note?: string }
+export interface ProviderPreset { key: string; name: string; protocols: ProviderPresetProtocol[] }
+export interface AddProviderReq { name: string; type: string; endpoint: string; token: string; model: string; temperature?: number; isActive: boolean; enable_thinking: boolean; api_mode: string; thinking_effort: string; thinking_budget: number; max_tokens: number; top_p: number | null; top_k: number | null; frequency_penalty: number | null; presence_penalty: number | null; repetition_penalty: number | null; provider_key: string; auth_header: string; url_mode: string }
 
 export interface MCPServerResp { id: string; name: string; server_url: string; headers: Record<string, any>; timeout: number; retry_count: number; tool_filter: string[]; auto_reconnect: boolean; is_active: boolean; created_at: string }
 export interface AddMCPServerReq { name: string; server_url: string; headers?: Record<string, any>; timeout?: number; retry_count?: number; tool_filter?: string[]; auto_reconnect?: boolean; is_active: boolean }
@@ -75,6 +77,10 @@ export const providerApi = {
   update: (id: string, data: AddProviderReq) => client.put(`/providers/${id}`, data),
   delete: (id: string) => client.delete(`/providers/${id}`),
   toggle: (id: string, is_active: boolean) => client.put(`/providers/${id}/toggle`, { is_active }),
+}
+
+export const providerPresetsApi = {
+  list: () => client.get('/providers/presets'),
 }
 
 // ======== MCP ========

--- a/web/src/views/ProvidersPage.vue
+++ b/web/src/views/ProvidersPage.vue
@@ -9,8 +9,11 @@
     </div>
     <v-data-table :headers="headers" :items="items" :loading="loading" items-per-page="20">
       <template #item.type="{ item }"><v-chip size="small" variant="tonal">{{ typeLabel(item.type) }}</v-chip></template>
+      <template #item.api_mode="{ item }">
+        <v-chip size="small" variant="tonal">{{ apiModeLabel(item.api_mode) }}</v-chip>
+      </template>
       <template #item.enable_thinking="{ item }">
-        <v-chip size="small" :color="item.enable_thinking ? 'primary' : 'default'" variant="tonal">{{ item.enable_thinking ? '开' : '关' }}</v-chip>
+        <v-chip size="small" :color="thinkingOn(item) ? 'primary' : 'default'" variant="tonal">{{ thinkingOn(item) ? '开' : '关' }}</v-chip>
       </template>
       <template #item.is_active="{ item }">
         <v-switch :model-value="item.is_active" color="primary" density="compact" hide-details @update:model-value="(v) => toggle(item.id, !!v)" />
@@ -22,21 +25,37 @@
     </v-data-table>
 
     <!-- Dialog -->
-    <v-dialog v-model="dialog" max-width="560">
+    <v-dialog v-model="dialog" max-width="640">
       <v-card rounded="lg">
         <v-card-title>{{ editing ? '编辑 Provider' : '新增 Provider' }}</v-card-title>
         <v-card-text>
           <v-form ref="formRef">
-            <v-text-field v-model="form.name" label="名称" class="mb-3" />
+            <v-text-field v-model="form.name" label="名称" class="mb-3"
+              @update:model-value="onNameChange" />
             <v-select v-model="form.type" :items="types" label="类型" class="mb-3" />
-            <v-text-field v-model="form.endpoint" label="API 地址" class="mb-3" />
+            <v-select v-model="form.api_mode" :items="apiModes" label="协议模式" class="mb-3" />
+
+            <!-- 国产厂商预设联动 -->
+            <v-select v-model="selectedPresetKey" :items="presetOptions" label="国产厂商预设（可选）" clearable class="mb-3"
+              @update:model-value="onPresetSelect" />
+            <v-select v-if="selectedPreset" v-model="selectedProtocolIdx" :items="protocolOptions" label="协议" class="mb-3"
+              @update:model-value="onProtocolSelect" />
+            <div v-if="selectedPresetNote" class="text-caption text-warning mb-3">{{ selectedPresetNote }}</div>
+
+            <v-text-field v-model="form.endpoint" label="API 地址" class="mb-3"
+              hint="可填 base URL 或完整端点（以协议后缀结尾自动识别）。完全自定义时需写 v1 后完整后缀。" persistent-hint />
             <v-text-field v-model="form.token" label="API Token" class="mb-3" />
             <v-text-field v-model="form.model" label="模型名" class="mb-3" />
+            <v-select v-model="form.auth_header" :items="authHeaders" label="认证头" clearable class="mb-3" hint="空 = 按协议默认" persistent-hint />
+            <v-select v-model="form.url_mode" :items="urlModes" label="URL 模式" class="mb-3" />
             <v-text-field v-model="form.temperature" label="温度" type="number" step="0.1" class="mb-3" />
-            <v-switch v-model="form.enable_thinking" label="模型思考" color="primary" class="mb-3" />
+            <v-select v-model="form.thinking_effort" :items="thinkingEfforts" label="思考档位" class="mb-3" />
+            <v-switch v-model="form.enable_thinking" label="模型思考（旧开关）" color="primary" class="mb-3" />
+            <v-text-field v-model="form.max_tokens" label="Max Tokens（0=协议默认）" type="number" class="mb-3" />
+            <v-text-field v-model="form.thinking_budget" label="Thinking Budget（0=默认）" type="number" class="mb-3" />
             <v-switch v-model="form.isActive" label="激活" color="primary" />
             <div class="text-caption text-medium-emphasis mt-2">
-              模型思考开启后，请求会携带 thinking / enable_thinking 扩展参数（DeepSeek、通义千问等思考模式兼容）。
+              思考档位支持 off/low/medium/high，按厂商矩阵适配（DeepSeek/智谱/Kimi/通义/阶跃/MiniMax 等）。
             </div>
           </v-form>
         </v-card-text>
@@ -64,8 +83,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { providerApi, type ProviderResp, type AddProviderReq } from '@/api'
+import { ref, onMounted, computed } from 'vue'
+import { providerApi, providerPresetsApi, type ProviderResp, type ProviderPreset, type AddProviderReq } from '@/api'
 import { useToastStore } from '@/stores/toast'
 
 const toastStore = useToastStore()
@@ -79,12 +98,16 @@ const deleting = ref(false)
 const deleteTarget = ref<ProviderResp | null>(null)
 const formRef = ref()
 
+const presets = ref<ProviderPreset[]>([])
+const selectedPresetKey = ref<string | null>(null)
+const selectedProtocolIdx = ref<number | null>(null)
+
 const headers = [
   { title: '名称', key: 'name' },
   { title: '类型', key: 'type' },
   { title: '模型', key: 'model' },
+  { title: '协议', key: 'api_mode', align: 'center' as const },
   { title: '端点', key: 'endpoint' },
-  { title: '温度', key: 'temperature' },
   { title: '思考', key: 'enable_thinking', align: 'center' as const },
   { title: 'Active', key: 'is_active', align: 'center' as const },
   { title: '操作', key: 'actions', align: 'center' as const, sortable: false },
@@ -96,9 +119,50 @@ const types = [
   { title: 'Embedding Model', value: 'embedding_model' },
 ]
 
-const typeLabel = (t: string) => ({ text_model: 'Text', image_model: 'Image', embedding_model: 'Embedding' }[t] || t)
+const apiModes = [
+  { title: 'OpenAI 兼容 (chat_completions)', value: 'chat_completions' },
+  { title: 'Anthropic Messages', value: 'anthropic_messages' },
+  { title: 'OpenAI Responses', value: 'openai_responses' },
+  { title: 'Gemini Native', value: 'gemini_native' },
+]
 
-const defaultForm = (): AddProviderReq => ({ name: '', type: 'text_model', endpoint: '', token: '', model: '', temperature: 0.7, isActive: false, enable_thinking: false })
+const authHeaders = [
+  { title: 'Bearer', value: 'bearer' },
+  { title: 'x-api-key', value: 'x-api-key' },
+  { title: 'api-key', value: 'api-key' },
+]
+
+const urlModes = [
+  { title: '自动（base + 协议后缀）', value: 'auto' },
+  { title: '完全自定义（原样使用）', value: 'exact' },
+]
+
+const thinkingEfforts = [
+  { title: '关闭', value: 'off' },
+  { title: '低', value: 'low' },
+  { title: '中', value: 'medium' },
+  { title: '高', value: 'high' },
+]
+
+const typeLabel = (t: string) => ({ text_model: 'Text', image_model: 'Image', embedding_model: 'Embedding' }[t] || t)
+const apiModeLabel = (m: string) => ({ chat_completions: 'OpenAI', anthropic_messages: 'Anthropic', openai_responses: 'Responses', gemini_native: 'Gemini' }[m] || m || 'OpenAI')
+const thinkingOn = (item: ProviderResp) => item.thinking_effort === 'off' ? false : (item.enable_thinking || item.thinking_effort !== '')
+
+const presetOptions = computed(() => presets.value.map(p => ({ title: p.name, value: p.key })))
+const selectedPreset = computed(() => presets.value.find(p => p.key === selectedPresetKey.value) || null)
+const protocolOptions = computed(() => selectedPreset.value ? selectedPreset.value.protocols.map((p, i) => ({ title: apiModeLabel(p.api_mode), value: i })) : [])
+const selectedPresetNote = computed(() => {
+  const p = selectedPreset.value
+  if (!p || selectedProtocolIdx.value == null) return ''
+  return p.protocols[selectedProtocolIdx.value]?.note || ''
+})
+
+const defaultForm = (): AddProviderReq => ({
+  name: '', type: 'text_model', endpoint: '', token: '', model: '', temperature: 0.7,
+  isActive: false, enable_thinking: false, api_mode: 'chat_completions', thinking_effort: 'off',
+  thinking_budget: 0, max_tokens: 0, top_p: null, top_k: null, frequency_penalty: null,
+  presence_penalty: null, repetition_penalty: null, provider_key: '', auth_header: '', url_mode: 'auto',
+})
 const form = ref<AddProviderReq>(defaultForm())
 
 async function fetch() {
@@ -106,11 +170,57 @@ async function fetch() {
   try { items.value = (await providerApi.list()).data.data } catch (e: any) { toastStore.error('获取列表失败') } finally { loading.value = false }
 }
 
-function openAdd() { editing.value = null; form.value = defaultForm(); dialog.value = true }
+async function fetchPresets() {
+  try { presets.value = (await providerPresetsApi.list()).data.data } catch (e: any) { /* 预设可选，失败静默 */ }
+}
+
+function openAdd() {
+  editing.value = null
+  form.value = defaultForm()
+  selectedPresetKey.value = null
+  selectedProtocolIdx.value = null
+  dialog.value = true
+}
 function openEdit(item: ProviderResp) {
   editing.value = item.id
-  form.value = { name: item.name, type: item.type, endpoint: item.endpoint, token: item.token, model: item.model, temperature: item.temperature, isActive: item.is_active, enable_thinking: item.enable_thinking }
+  form.value = {
+    name: item.name, type: item.type, endpoint: item.endpoint, token: item.token, model: item.model,
+    temperature: item.temperature, isActive: item.is_active, enable_thinking: item.enable_thinking,
+    api_mode: item.api_mode || 'chat_completions', thinking_effort: item.thinking_effort || 'off',
+    thinking_budget: item.thinking_budget || 0, max_tokens: item.max_tokens || 0,
+    top_p: item.top_p, top_k: item.top_k, frequency_penalty: item.frequency_penalty,
+    presence_penalty: item.presence_penalty, repetition_penalty: item.repetition_penalty,
+    provider_key: item.provider_key || '', auth_header: item.auth_header || '', url_mode: item.url_mode || 'auto',
+  }
+  selectedPresetKey.value = item.provider_key || null
+  selectedProtocolIdx.value = null
   dialog.value = true
+}
+
+// 名称关键词命中预设厂商时自动带出 provider_key，便于 thinking 矩阵生效。
+function onNameChange(v: string | null) {
+  if (!v || editing.value) return
+  const n = v.toLowerCase()
+  const match = presets.value.find(p => n.includes(p.key) || n.includes(p.name.toLowerCase()))
+  if (match) form.value.provider_key = match.key
+}
+
+function onPresetSelect(key: string | null) {
+  selectedProtocolIdx.value = null
+  if (!key) return
+  form.value.provider_key = key
+  const p = presets.value.find(x => x.key === key)
+  if (p && p.protocols.length) selectedProtocolIdx.value = 0
+}
+
+function onProtocolSelect(idx: number | null) {
+  const p = selectedPreset.value
+  if (!p || idx == null) return
+  const proto = p.protocols[idx]
+  form.value.api_mode = proto.api_mode
+  form.value.endpoint = proto.base_url
+  form.value.auth_header = proto.auth_header
+  form.value.url_mode = 'auto'
 }
 
 async function toggle(id: string, v: boolean) {
@@ -138,5 +248,5 @@ async function handleDelete() {
   try { await providerApi.delete(deleteTarget.value.id); toastStore.success('已删除'); deleteDialog.value = false; await fetch() } catch (e: any) { toastStore.error('删除失败') } finally { deleting.value = false }
 }
 
-onMounted(fetch)
+onMounted(() => { fetch(); fetchPresets() })
 </script>

--- a/web/src/views/ProvidersPage.vue
+++ b/web/src/views/ProvidersPage.vue
@@ -19,48 +19,131 @@
         <v-switch :model-value="item.is_active" color="primary" density="compact" hide-details @update:model-value="(v) => toggle(item.id, !!v)" />
       </template>
       <template #item.actions="{ item }">
+        <v-btn icon="mdi-sync" size="small" variant="text" color="secondary" title="测试连接" :loading="testingId === item.id" @click="testItem(item)" />
         <v-btn icon="mdi-pencil" size="small" variant="text" color="primary" @click="openEdit(item)" />
         <v-btn icon="mdi-delete" size="small" variant="text" color="error" @click="confirmDelete(item)" />
       </template>
     </v-data-table>
 
     <!-- Dialog -->
-    <v-dialog v-model="dialog" max-width="640">
+    <v-dialog v-model="dialog" max-width="960">
       <v-card rounded="lg">
-        <v-card-title>{{ editing ? '编辑 Provider' : '新增 Provider' }}</v-card-title>
+        <v-card-title class="d-flex align-center">
+          <span class="me-auto">{{ editing ? '编辑 Provider' : '新增 Provider' }}</span>
+          <v-btn v-if="editing" variant="tonal" color="secondary" prepend-icon="mdi-sync" :loading="testing" @click="testForm">测试连接</v-btn>
+        </v-card-title>
         <v-card-text>
           <v-form ref="formRef">
-            <v-text-field v-model="form.name" label="名称" class="mb-3"
-              @update:model-value="onNameChange" />
-            <v-select v-model="form.type" :items="types" label="类型" class="mb-3" />
-            <v-select v-model="form.api_mode" :items="apiModes" label="协议模式" class="mb-3" />
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-text-field v-model="form.name" label="名称" @update:model-value="onNameChange" />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-select v-model="form.type" :items="types" label="类型" />
+              </v-col>
+            </v-row>
 
-            <!-- 国产厂商预设联动 -->
-            <v-select v-model="selectedPresetKey" :items="presetOptions" label="国产厂商预设（可选）" clearable class="mb-3"
-              @update:model-value="onPresetSelect" />
-            <v-select v-if="selectedPreset" v-model="selectedProtocolIdx" :items="protocolOptions" label="协议" class="mb-3"
-              @update:model-value="onProtocolSelect" />
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-select v-model="form.api_mode" :items="apiModes" label="协议模式" />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-select v-model="form.url_mode" :items="urlModes" label="URL 模式" />
+              </v-col>
+            </v-row>
+
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-select v-model="selectedPresetKey" :items="presetOptions" label="厂商预设（可选）" clearable @update:model-value="onPresetSelect" />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-select v-if="selectedPreset" v-model="selectedProtocolIdx" :items="protocolOptions" label="协议" @update:model-value="onProtocolSelect" />
+              </v-col>
+            </v-row>
             <div v-if="selectedPresetNote" class="text-caption text-warning mb-3">{{ selectedPresetNote }}</div>
 
-            <v-text-field v-model="form.endpoint" label="API 地址" class="mb-3"
-              hint="可填 base URL 或完整端点（以协议后缀结尾自动识别）。完全自定义时需写 v1 后完整后缀。" persistent-hint />
-            <v-text-field v-model="form.token" label="API Token" class="mb-3" />
-            <v-text-field v-model="form.model" label="模型名" class="mb-3" />
-            <v-select v-model="form.auth_header" :items="authHeaders" label="认证头" clearable class="mb-3" hint="空 = 按协议默认" persistent-hint />
-            <v-select v-model="form.url_mode" :items="urlModes" label="URL 模式" class="mb-3" />
-            <v-text-field v-model="form.temperature" label="温度" type="number" step="0.1" class="mb-3" />
-            <v-select v-model="form.thinking_effort" :items="thinkingEfforts" label="思考档位" class="mb-3" />
-            <v-switch v-model="form.enable_thinking" label="模型思考（旧开关）" color="primary" class="mb-3" />
-            <v-text-field v-model="form.max_tokens" label="Max Tokens（0=协议默认）" type="number" class="mb-3" />
-            <v-text-field v-model="form.thinking_budget" label="Thinking Budget（0=默认）" type="number" class="mb-3" />
-            <v-switch v-model="form.isActive" label="激活" color="primary" />
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-text-field v-model="form.endpoint" label="API 地址" hint="可填 base URL 或完整端点（以协议后缀结尾自动识别）" persistent-hint />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-text-field v-model="form.token" label="API Token" type="password" />
+              </v-col>
+            </v-row>
+
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-text-field v-model="form.model" label="模型名" />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-select v-model="form.auth_header" :items="authHeaders" label="认证头" clearable hint="空 = 按协议默认" persistent-hint />
+              </v-col>
+            </v-row>
+
+            <v-divider class="my-2" />
+            <div class="text-subtitle-2 mb-2">基础参数</div>
+            <v-row>
+              <v-col cols="12" sm="6" md="4">
+                <v-text-field v-model="form.temperature" label="温度" type="number" step="0.1" />
+              </v-col>
+              <v-col cols="12" sm="6" md="4">
+                <v-text-field v-model="form.max_tokens" label="Max Tokens（0=默认）" type="number" />
+              </v-col>
+              <v-col cols="12" sm="6" md="4">
+                <v-switch v-model="form.isActive" label="激活" color="primary" />
+              </v-col>
+            </v-row>
+
+            <template v-if="show.thinking">
+              <v-divider class="my-2" />
+              <div class="text-subtitle-2 mb-2">思考（Thinking）</div>
+              <v-row>
+                <v-col cols="12" sm="6" md="4">
+                  <v-select v-model="form.thinking_effort" :items="thinkingEfforts" label="思考档位" />
+                </v-col>
+                <v-col cols="12" sm="6" md="4">
+                  <v-text-field v-model="form.thinking_budget" label="Thinking Budget（0=默认）" type="number" />
+                </v-col>
+                <v-col cols="12" sm="6" md="4">
+                  <v-switch v-model="form.enable_thinking" label="模型思考（旧开关）" color="primary" />
+                </v-col>
+              </v-row>
+            </template>
+
+            <v-divider class="my-2" />
+            <div class="text-subtitle-2 mb-2">高级采样参数（可选）</div>
+            <v-row>
+              <v-col v-if="show.topP" cols="12" sm="6" md="4">
+                <v-text-field v-model="form.top_p" label="Top P" type="number" step="0.05" />
+              </v-col>
+              <v-col v-if="show.topK" cols="12" sm="6" md="4">
+                <v-text-field v-model="form.top_k" label="Top K" type="number" />
+              </v-col>
+              <v-col v-if="show.freqPresence" cols="12" sm="6" md="4">
+                <v-text-field v-model="form.frequency_penalty" label="Frequency Penalty" type="number" step="0.1" />
+              </v-col>
+              <v-col v-if="show.freqPresence" cols="12" sm="6" md="4">
+                <v-text-field v-model="form.presence_penalty" label="Presence Penalty" type="number" step="0.1" />
+              </v-col>
+              <v-col v-if="show.repetition" cols="12" sm="6" md="4">
+                <v-text-field v-model="form.repetition_penalty" label="Repetition Penalty" type="number" step="0.1" />
+              </v-col>
+            </v-row>
+
             <div class="text-caption text-medium-emphasis mt-2">
               思考档位支持 off/low/medium/high，按厂商矩阵适配（DeepSeek/智谱/Kimi/通义/阶跃/MiniMax 等）。
             </div>
           </v-form>
+
+          <!-- 测试结果状态 -->
+          <v-alert v-if="testResult !== null" :type="testResult.ok ? 'success' : 'error'" variant="tonal" class="mt-3" dense>
+            <template #prepend><v-icon>{{ testResult.ok ? 'mdi-check-circle' : 'mdi-alert-circle' }}</v-icon></template>
+            <div class="text-caption">{{ testResult.message }}</div>
+          </v-alert>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
+          <v-btn v-if="!editing" variant="tonal" color="secondary" prepend-icon="mdi-sync" :loading="testing" @click="testForm">测试连接</v-btn>
           <v-btn variant="text" @click="dialog = false">取消</v-btn>
           <v-btn color="primary" variant="tonal" @click="handleSave" :loading="saving">保存</v-btn>
         </v-card-actions>
@@ -84,7 +167,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
-import { providerApi, providerPresetsApi, type ProviderResp, type ProviderPreset, type AddProviderReq } from '@/api'
+import { providerApi, providerPresetsApi, type ProviderResp, type ProviderPreset, type AddProviderReq, type TestProviderResp } from '@/api'
 import { useToastStore } from '@/stores/toast'
 
 const toastStore = useToastStore()
@@ -95,6 +178,9 @@ const deleteDialog = ref(false)
 const editing = ref<string | null>(null)
 const saving = ref(false)
 const deleting = ref(false)
+const testing = ref(false)
+const testingId = ref<string | null>(null)
+const testResult = ref<TestProviderResp | null>(null)
 const deleteTarget = ref<ProviderResp | null>(null)
 const formRef = ref()
 
@@ -157,6 +243,26 @@ const selectedPresetNote = computed(() => {
   return p.protocols[selectedProtocolIdx.value]?.note || ''
 })
 
+// 支持 thinking 的厂商分组关键词（驱动 thinking 参数区显隐）。
+const thinkingPresetKeys = ['deepseek', 'zhipu', 'kimi', 'moonshot', 'alibaba', 'qwen', 'glm', 'stepfun', 'minimax', 'tencent']
+
+// 按协议模式 + 厂商参数化各配置项是否适用（选择提供商时隐藏不适用的配置）。
+const show = computed(() => {
+  const mode = form.value.api_mode
+  const pk = form.value.provider_key
+  const anthro = mode === 'anthropic_messages'
+  const gemini = mode === 'gemini_native'
+  const resp = mode === 'openai_responses'
+  const chat = mode === 'chat_completions'
+  return {
+    thinking: anthro || gemini || resp || thinkingPresetKeys.includes(pk),
+    topP: !resp,
+    topK: anthro || gemini || pk === 'minimax',
+    freqPresence: chat || resp,
+    repetition: gemini || pk === 'minimax' || pk === 'xiaomi',
+  }
+})
+
 const defaultForm = (): AddProviderReq => ({
   name: '', type: 'text_model', endpoint: '', token: '', model: '', temperature: 0.7,
   isActive: false, enable_thinking: false, api_mode: 'chat_completions', thinking_effort: 'off',
@@ -179,6 +285,7 @@ function openAdd() {
   form.value = defaultForm()
   selectedPresetKey.value = null
   selectedProtocolIdx.value = null
+  testResult.value = null
   dialog.value = true
 }
 function openEdit(item: ProviderResp) {
@@ -194,6 +301,7 @@ function openEdit(item: ProviderResp) {
   }
   selectedPresetKey.value = item.provider_key || null
   selectedProtocolIdx.value = null
+  testResult.value = null
   dialog.value = true
 }
 
@@ -239,6 +347,52 @@ async function handleSave() {
     dialog.value = false
     await fetch()
   } catch (e: any) { toastStore.error(e?.message || '保存失败') } finally { saving.value = false }
+}
+
+function reqFromItem(item: ProviderResp): AddProviderReq {
+  return {
+    name: item.name, type: item.type, endpoint: item.endpoint, token: item.token, model: item.model,
+    temperature: item.temperature, isActive: item.is_active, enable_thinking: item.enable_thinking,
+    api_mode: item.api_mode || 'chat_completions', thinking_effort: item.thinking_effort || 'off',
+    thinking_budget: item.thinking_budget || 0, max_tokens: item.max_tokens || 0,
+    top_p: item.top_p, top_k: item.top_k, frequency_penalty: item.frequency_penalty,
+    presence_penalty: item.presence_penalty, repetition_penalty: item.repetition_penalty,
+    provider_key: item.provider_key || '', auth_header: item.auth_header || '', url_mode: item.url_mode || 'auto',
+  }
+}
+
+async function runTest(payload: AddProviderReq) {
+  testing.value = true
+  try {
+    const res = (await providerApi.test(payload)).data.data as TestProviderResp
+    testResult.value = res
+    if (res.ok) {
+      toastStore.success('连接成功')
+    } else {
+      toastStore.error(res.message || '连接失败')
+    }
+  } catch (e: any) {
+    testResult.value = { ok: false, message: e?.message || '测试失败' }
+    toastStore.error('测试失败')
+  } finally { testing.value = false }
+}
+
+// 测试新增/编辑表单中的当前配置（不落库）。
+function testForm() { runTest({ ...form.value }) }
+
+// 测试列表中已保存的 Provider。
+async function testItem(item: ProviderResp) {
+  testingId.value = item.id
+  try {
+    const res = (await providerApi.test(reqFromItem(item))).data.data as TestProviderResp
+    if (res.ok) {
+      toastStore.success('连接成功')
+    } else {
+      toastStore.error(res.message || '连接失败')
+    }
+  } catch (e: any) {
+    toastStore.error(e?.message || '测试失败')
+  } finally { testingId.value = null }
 }
 
 function confirmDelete(item: ProviderResp) { deleteTarget.value = item; deleteDialog.value = true }


### PR DESCRIPTION
### 摘要

本次 PR 以「多协议 LLM Provider 适配」为核心，将原本仅支持 OpenAI `chat_completions` 单一协议的 Provider 扩展为四大协议（`chat_completions` / `anthropic_messages` / `openai_responses` / `gemini_native`），配套升级了 Web 管理界面（双列布局、按厂商隐藏配置、新增连接测试），并新增图床/知识库检索内置工具、修复表情包 SQL 语法问题、将短期记忆改为 per-ChatArea 配置。

### 主要改动

#### 🧠 Provider 多协议适配（核心）
- **`internal/agent/provider/`**：`provider.go` 重构为多协议客户端，按 `APIMode` 分派请求构造、响应解析与流式解析；新增 URL 拼接规则（base + 协议后缀自动拼接 / 完整端点识别 / `url_mode=exact` 原样使用）。
- **Thinking 适配矩阵（§5.5）**：新增 `applyThinking`，按厂商 + 模型匹配不同思考模式（`reasoning_effort` / `thinking_object` / `enable_thinking` / `thinking_config` / `budget_tokens` / `adaptive`），支持 `ThinkingEffort`（off/low/medium/high）与 `ThinkingBudget`。
- **`models_catalog.go`**（新增）：模型能力元数据表（上下文窗口、最大输出、思考模式、支持参数），MaxTokens 默认值校验基础。
- **`provider_presets.go`**（新增）：国产厂商（DeepSeek/智谱/Kimi/阿里百炼/火山方舟/MiniMax/小米/阶跃/腾讯/百度/硅基流动）的协议能力预设表，前端据此渲染「厂商 → 协议」下拉并自动预填。
- **`provider_test.go`**（新增）：14 个单元测试覆盖 URL 拼接、各协议请求构造/响应/流式解析、thinking 矩阵、认证头等。
- **`root.go`**：新增 `APIMode` 常量、`ProviderConfig` 扩展字段、`ProviderConfigFromModel` 统一模型→运行时配置映射（消除多处分段赋值遗漏）。

#### 🖥️ Provider 管理界面升级（`web/src/views/ProvidersPage.vue`）
- 双列布局 + 按协议/厂商动态**隐藏不适用配置**；新增厂商预设选择与协议下拉联动。
- 同时支持协议模式、URL 模式、认证头、thinking 档位、max_tokens 及高级采样参数（top_p/top_k/penalties）。
- 新增**连接测试**功能（列表行内 + 表单内），调用新增 `POST /api/v1/providers/test` 接口（`service.go` 的 `TestProvider`，不落库、不影响运行时）。

#### 🤖 Agent 内置工具
- 新增 `search_images`：按图片展示名模糊搜索图床（`imageDao.SearchByName`，前缀优先排序），返回 ID 供 `[CQ:image,file=imgs://ID]` 引用。
- 新增 `search_knowledge`：按需主动检索知识库（区别于对话前自动注入），内容超长自动截断。

#### 🧠 短期记忆 per-ChatArea 配置
- `memory.go`：新增 `ShortTermStore` 接口 + per-ChatArea 配置缓存（cache → DB → 全局默认三级解析），`UpdateShortTermConfig` 改为按 areaID 更新。
- `shortterm.go`：新增 `AddWithWindow`/`OverwriteWithWindow`，窗口按 area 独立维护，避免全局共享配置互相覆盖。
- 默认配置改为 `AutoCompact=true` / `WindowSize=100`（`shortTermMemDao.go`、`shortTermMem.go`）。

#### 🐛 修复
- `stickerDao.go`：修复 `tags ?? ?` 的 `?` 占位符转义问题（改 `@>` 包含操作符 + JSON 数组参数）；修复 `desc` 保留字未加引号导致的 SQL 语法错误。
- `knowledge.go`：`searchKnowledgeForTool` 增加 `preprocessKnowledgeQuery` 关键词预处理。

### 涉及文件
- 后端：`internal/agent/*`、`internal/agent/memory/*`、`internal/agent/provider/*`、`internal/agent/tool/builtin.go`、`internal/api/*`、`internal/core/dao/*`、`internal/core/models/*`
- 前端：`web/src/views/ProvidersPage.vue`、`web/src/api/index.ts