### PR TITLE
feat(t2i,pluggin): 渲染 options 表 + jn.llm 异步 API 注册表

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -233,6 +233,7 @@ func main() {
 		nil,
 		coreInst.DAO,
 		hago,
+		hago,
 	)
 	if err := pluginEngine.LoadAll(); err != nil {
 		log.Error("插件加载失败", "err", err)

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -104,6 +104,7 @@ SDK 仅是 Go 注入全局表的再导出（`jn.log = log` 等），不引入额
 | `jn.t2i` | `t2i` | 文生图 |
 | `jn.sandbox` | `sandbox` | 代码沙箱 |
 | `jn.agent` | `agent` | Agent 操作接口 |
+| `jn.llm` | `llm` | LLM 调用（复用 Bot Provider 配置） |
 | `jn.file` | `file` | 插件目录内文本文件读写 |
 | `jn.command` | — | 命令注册 |
 
@@ -475,6 +476,54 @@ jn.agent.set_provider_active("uuid", true)   -- 启用
 |------|------|------|
 | `agent.get_current_chat_area() → table` | `{post_type, message_type, user_id, group_id, chat_area_id}` | 当前正在处理的消息所属 ChatArea |
 | `agent.compact_memory() → string [, err]` | | Compact 当前 ChatArea 短期记忆：LLM 压缩为摘要写入长期记忆，随后窗口清理为只保留最近 10 条消息（需 Text LLM Provider） |
+
+## SDK 模块: `jn.llm`
+
+权限：`llm`。通过 **Bot 自身启用的文本模型 Provider** 调用 LLM——模型、采样参数、密钥全部复用 Bot 配置，插件不接触任何密钥。适合内容审查、二次判断等场景。
+
+```lua
+local jn = require("jn")
+
+-- 同步调用（适合命令等低频路径）
+local content, err = jn.llm.chat("你好", { timeout = 30 })
+
+-- 异步调用（高频路径必须用异步：不阻塞事件循环与其它插件）
+local rid = jn.llm.chat_async(
+    { { role = "system", content = "你是审查员" }, { role = "user", content = "待审查消息" } },
+    { timeout = 60 }
+)  -- 立即返回 req_id（失败返回 0）
+
+-- 完成后引擎调用插件入口函数（引擎级异步注册表派发）：
+function on_chat_response(req_id, content, err)
+    if err then
+        log.warn("LLM 调用失败: " .. err)
+        return
+    end
+    log.info("LLM 返回: " .. content)
+end
+```
+
+| 函数 | 说明 |
+|------|------|
+| `llm.available() → bool` | 当前是否有可用的文本模型 Provider |
+| `llm.chat(messages, opts?) → string?, string?` | 同步调用，返回 `(content, err)`；err 为 nil 表示成功 |
+| `llm.chat_async(messages, opts?) → number` | 异步提交，立即返回 `req_id`（失败返回 `0`）；完成后引擎派发到插件入口 `on_chat_response(req_id, content, err)` |
+
+参数：
+
+- `messages`：单字符串（role=`user`）或数组。数组元素可为字符串（role=`user`）或 `{role="system|user|assistant", content="..."}`。
+- `opts`：`{temperature=?, max_tokens=?, timeout=?秒}`；**缺省采样参数回退 Bot Provider 配置**，`timeout` 缺省 60s。
+- `on_chat_response` 的 `req_id` 与 `chat_async` 返回值一致，用于关联请求上下文（例如维护 `req_id → 消息/关键词` 映射表，回调时取回）。
+
+### 异步 API 注册表
+
+`chat_async` 由引擎级**异步注册表**驱动（`PluginEngine.RegisterAsyncAPI`，kind `"chat"`）：
+
+- 提交后立即返回 `req_id`，阻塞操作（HTTP 调用）在独立 goroutine 完成，**不阻塞事件循环**；
+- 完成后引擎串行派发到插件 Lua 入口函数 `on_xxx_response`（与事件派发互斥，保证 LState 安全）；
+- 插件卸载后未派发的任务自动丢弃。
+
+后续新增异步 API（如 `t2i.generate_async` → `on_t2i_response`、`http.get_async` → `on_http_response`）只需在 Go 侧注册一个 kind，插件侧遵循同一约定：`xxx_async(...) → req_id`，`on_xxx_response(req_id, <结果...>)`。
 
 ## SDK 模块: `jn.command`
 

--- a/internal/adapter/models.go
+++ b/internal/adapter/models.go
@@ -164,6 +164,8 @@ type GroupMemberInfo struct {
 	Title           string `json:"title"`
 	TitleExpireTime int64  `json:"title_expire_time"`
 	CardChangeable  bool   `json:"card_changeable"`
+	// ShutUpTimestamp 禁言到期时间戳（秒）；0 或小于当前时间表示未在禁言中。
+	ShutUpTimestamp int64 `json:"shut_up_timestamp"`
 }
 
 type GroupHonorInfo struct {

--- a/internal/agent/agent_operator.go
+++ b/internal/agent/agent_operator.go
@@ -267,6 +267,25 @@ func (h *HagoCenter) SetSandboxActive(ctx context.Context, active bool) error {
 	return nil
 }
 
+// ---------- LLMAccess ----------
+
+var _ pluggin.LLMAccess = (*HagoCenter)(nil)
+
+// Chat 使用 Bot 当前启用的文本模型 Provider 调用 LLM。
+// 复用 Bot 的模型 / 采样参数 / 密钥配置（req 未设置的采样参数回退 Bot 配置）。
+func (h *HagoCenter) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	pr := h.Providers.SelectModel(provider.ModelTypeText)
+	if pr == nil {
+		return nil, fmt.Errorf("无可用文本模型 Provider")
+	}
+	return pr.Chat(ctx, req)
+}
+
+// Available 当前是否有启用的文本模型 Provider。
+func (h *HagoCenter) Available() bool {
+	return h.Providers.SelectModel(provider.ModelTypeText) != nil
+}
+
 // ---------- ProviderGroupAccess ----------
 
 type providerGroupAccess struct{ h *HagoCenter }

--- a/internal/pluggin/llm_review_test.go
+++ b/internal/pluggin/llm_review_test.go
@@ -363,9 +363,9 @@ func TestRedrockBlackGraySensitive(t *testing.T) {
 		t.Fatalf("敏感词不应触发 LLM, calls=%d", llm.callCount())
 	}
 
-	// 3. 灰色地带：命中 all.txt 灰色词（考研/加群/资料群）→ 不消费、不立即处罚，异步触发 LLM
+	// 3. 灰色地带：命中 all.txt 灰色词（考研/加群）→ 不消费、不立即处罚，异步触发 LLM
 	llm.setReply(`{"violation":"ad","reason":"以资料分享为幌子拉群引流"}`)
-	consumed = runOnMessage(t, L, 10001, 20003, "考研资料群，无偿分享，加群领资料", "90003")
+	consumed = runOnMessage(t, L, 10001, 20003, "考研上岸的学长学姐，加群一起交流经验", "90003")
 	if consumed {
 		t.Fatal("灰色词消息不应被消费（先放行）")
 	}

--- a/internal/pluggin/llm_review_test.go
+++ b/internal/pluggin/llm_review_test.go
@@ -1,0 +1,440 @@
+package pluggin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"JuanNiang-Neo/internal/agent/provider"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// ---------- 测试替身 ----------
+
+// fakeAdapter 空实现 SendAdapter，记录关键调用。
+type fakeAdapter struct {
+	mu         sync.Mutex
+	deleted    []int64
+	groups     []string
+	muted      []string
+	kicked     []string
+	mutedUsers map[int64]bool // 模拟处于禁言中的用户
+}
+
+func (f *fakeAdapter) SendPrivateMsg(userID int64, message any) (int64, error) { return 0, nil }
+func (f *fakeAdapter) SendGroupMsg(groupID int64, message any) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.groups = append(f.groups, fmt.Sprintf("%v", message))
+	return 0, nil
+}
+func (f *fakeAdapter) DeleteMsg(messageID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, messageID)
+	return nil
+}
+func (f *fakeAdapter) GetMsg(messageID int64) (map[string]any, error) { return nil, nil }
+func (f *fakeAdapter) GetGroupInfo(groupID int64) (map[string]any, error) {
+	return map[string]any{"group_name": "test"}, nil
+}
+func (f *fakeAdapter) GetGroupMemberList(groupID int64) ([]map[string]any, error) { return nil, nil }
+func (f *fakeAdapter) KickGroupMember(groupID, userID int64, rejectAdd bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.kicked = append(f.kicked, fmt.Sprintf("%d:%d", groupID, userID))
+	return nil
+}
+func (f *fakeAdapter) BanGroupMember(groupID, userID int64, duration int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.muted = append(f.muted, fmt.Sprintf("%d:%d:%d", groupID, userID, duration))
+	return nil
+}
+func (f *fakeAdapter) SetGroupWholeBan(groupID int64, enable bool) error     { return nil }
+func (f *fakeAdapter) SetGroupCard(groupID, userID int64, card string) error { return nil }
+func (f *fakeAdapter) HandleFriendRequest(flag string, approve bool, remark string) error {
+	return nil
+}
+func (f *fakeAdapter) HandleGroupRequest(flag, subType string, approve bool, reason string) error {
+	return nil
+}
+func (f *fakeAdapter) GetLoginInfo() (map[string]any, error) { return nil, nil }
+func (f *fakeAdapter) GetStrangerInfo(userID int64) (map[string]any, error) {
+	return nil, nil
+}
+func (f *fakeAdapter) GetFriendList() ([]map[string]any, error) { return nil, nil }
+func (f *fakeAdapter) GetGroupList() ([]map[string]any, error)  { return nil, nil }
+func (f *fakeAdapter) GetGroupMemberInfo(groupID, userID int64) (map[string]any, error) {
+	info := map[string]any{"role": "member", "shut_up_timestamp": int64(0)}
+	f.mu.Lock()
+	if f.mutedUsers[userID] {
+		info["shut_up_timestamp"] = time.Now().Add(30 * time.Minute).Unix()
+	}
+	f.mu.Unlock()
+	return info, nil
+}
+func (f *fakeAdapter) GetGroupHonorInfo(groupID int64) (map[string]any, error) { return nil, nil }
+func (f *fakeAdapter) SendLike(userID int64, times int) error                  { return nil }
+func (f *fakeAdapter) GetStatus() (map[string]any, error)                      { return nil, nil }
+func (f *fakeAdapter) GetVersionInfo() (map[string]any, error)                 { return nil, nil }
+
+func (f *fakeAdapter) deletedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.deleted)
+}
+
+func (f *fakeAdapter) mutedCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]string{}, f.muted...)
+	return out
+}
+
+// fakeLLM 可编程 LLM 替身，实现 LLMAccess。
+type fakeLLM struct {
+	mu    sync.Mutex
+	reply string
+	err   error
+	calls int
+}
+
+func (f *fakeLLM) Available() bool { return true }
+
+func (f *fakeLLM) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &provider.ChatResponse{Message: provider.ChatMessage{Role: "assistant", Content: f.reply}}, nil
+}
+
+func (f *fakeLLM) setReply(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reply = s
+}
+
+func (f *fakeLLM) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// ---------- 工具 ----------
+
+// copyPlugin 把真实插件目录复制到临时目录，避免测试中的 save_config 写回污染真实文件。
+func copyPlugin(t *testing.T, dst string) {
+	t.Helper()
+	src := filepath.Join("..", "..", "..", "Plugins", "plugins", "redrock_group_manager")
+	filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+func newTestEngine(t *testing.T, llm LLMAccess) (*PluginEngine, *fakeAdapter, string) {
+	t.Helper()
+	adp := &fakeAdapter{mu: sync.Mutex{}, mutedUsers: make(map[int64]bool)}
+	base := t.TempDir()
+	pluginDir := filepath.Join(base, "redrock_group_manager")
+	copyPlugin(t, pluginDir)
+	pe := NewPluginEngine(base, adp, nil, nil, nil, nil, nil, nil, llm)
+	return pe, adp, base
+}
+
+// loadPluginManual 手动注入 + 执行插件入口，并把插件注册进 engine（供异步回调 runner 使用）。
+func loadPluginManual(t *testing.T, pe *PluginEngine, name string) *lua.LState {
+	t.Helper()
+	pluginDir := filepath.Join(pe.basePath, name)
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+
+	pe.injectSDK(L, name)
+	pe.injectBaseAPI(L, name, []string{"onebot11", "database", "file", "llm"})
+	// database 需要 gorm db（测试环境不提供），手写空实现（插件 init_db 用）
+	dbTable := L.NewTable()
+	L.SetFuncs(dbTable, map[string]lua.LGFunction{
+		"exec": func(L *lua.LState) int {
+			L.Push(lua.LBool(true))
+			return 1
+		},
+		"query": func(L *lua.LState) int {
+			L.Push(L.NewTable())
+			return 1
+		},
+	})
+	L.SetGlobal("database", dbTable)
+	pe.injectCommandAPI(L, name)
+
+	// require("jn")：优先加载插件目录内已同步的 jn.lua
+	L.DoString(fmt.Sprintf(`package.path = %q .. ";" .. package.path`, pluginDir+"/?.lua"))
+
+	if err := L.DoFile(filepath.Join(pluginDir, "main.lua")); err != nil {
+		t.Fatalf("加载插件 %s 失败: %v", name, err)
+	}
+
+	pe.mu.Lock()
+	pe.plugins[name] = &LoadedPlugin{Manifest: Manifest{Name: name}, State: L, Dir: pluginDir}
+	pe.mu.Unlock()
+	return L
+}
+
+// runOnMessage 构造群消息事件并调用插件 on_message，返回是否被消费。
+func runOnMessage(t *testing.T, L *lua.LState, groupID, userID int64, raw, msgID string) bool {
+	t.Helper()
+	fn := L.GetGlobal("on_message")
+	if fn.Type() != lua.LTFunction {
+		t.Fatal("on_message 未定义")
+	}
+	L.Push(fn)
+	ev := L.NewTable()
+	L.SetField(ev, "post_type", lua.LString("message"))
+	L.SetField(ev, "message_type", lua.LString("group"))
+	L.SetField(ev, "group_id", lua.LNumber(groupID))
+	L.SetField(ev, "user_id", lua.LNumber(userID))
+	L.SetField(ev, "raw_message", lua.LString(raw))
+	L.SetField(ev, "message_id", lua.LString(msgID))
+	L.SetField(ev, "admins", L.NewTable())
+	L.Push(ev)
+	if err := L.PCall(1, 2, nil); err != nil {
+		t.Fatalf("on_message 执行失败: %v", err)
+	}
+	consumed := bool(L.Get(-2).(lua.LBool))
+	L.Pop(2)
+	return consumed
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("等待条件超时")
+}
+
+// ---------- 测试: jn.llm Go 机制（同步 / 异步 / 回调 / 错误） ----------
+
+const llmTestPluginMain = `-- llm 机制测试插件（异步注册表 kind "chat" → on_chat_response）
+avail = llm.available()
+local content, err = llm.chat("hi", { timeout = 10 })
+synced = content
+done_count = 0
+last_rid = -1
+last_content = ""
+last_err = ""
+cb_submitted = -1
+function on_chat_response(req_id, content, err)
+    last_rid = req_id
+    last_content = tostring(content)
+    last_err = tostring(err)
+    done_count = done_count + 1
+end
+cb_submitted = llm.chat_async("hi", { timeout = 10 })
+`
+
+func writeTestPlugin(t *testing.T, base, name string) {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pluggin.yaml"),
+		[]byte("name: "+name+"\nversion: \"1.0.0\"\nentry: main.lua\npermissions:\n  - llm\nenabled: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.lua"), []byte(llmTestPluginMain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLLMInjectSyncAndAsync(t *testing.T) {
+	llm := &fakeLLM{reply: `{"violation":"none"}`}
+	adp := &fakeAdapter{}
+	base := t.TempDir()
+	pe := NewPluginEngine(base, adp, nil, nil, nil, nil, nil, nil, llm)
+	writeTestPlugin(t, base, "llmtest")
+
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+	pe.injectSDK(L, "llmtest")
+	pe.injectBaseAPI(L, "llmtest", []string{"llm"})
+	L.DoString(fmt.Sprintf(`package.path = %q .. ";" .. package.path`, filepath.Join(base, "llmtest")+"/?.lua"))
+	if err := L.DoFile(filepath.Join(base, "llmtest", "main.lua")); err != nil {
+		t.Fatalf("加载测试插件失败: %v", err)
+	}
+	pe.mu.Lock()
+	pe.plugins["llmtest"] = &LoadedPlugin{Manifest: Manifest{Name: "llmtest"}, State: L, Dir: filepath.Join(base, "llmtest")}
+	pe.mu.Unlock()
+
+	if v := L.GetGlobal("avail"); v.Type() != lua.LTBool || !bool(v.(lua.LBool)) {
+		t.Fatalf("llm.available() 应为 true, got %v", v)
+	}
+	if v := L.GetGlobal("synced"); v.Type() != lua.LTString || v.String() != `{"violation":"none"}` {
+		t.Fatalf("llm.chat 同步结果 = %v", v)
+	}
+	// 异步：chat_async 立即返回 req_id > 0，完成后引擎派发 on_chat_response
+	submitted := L.GetGlobal("cb_submitted")
+	if submitted.Type() != lua.LTNumber || float64(submitted.(lua.LNumber)) <= 0 {
+		t.Fatalf("chat_async 应返回 req_id > 0, got %v", submitted)
+	}
+	waitFor(t, func() bool {
+		v := L.GetGlobal("done_count")
+		return v.Type() == lua.LTNumber && float64(v.(lua.LNumber)) >= 1
+	})
+	if v := L.GetGlobal("last_rid"); v.String() != submitted.String() {
+		t.Fatalf("on_chat_response req_id = %v, want 与提交返回值一致 %v", v, submitted)
+	}
+	if v := L.GetGlobal("last_content"); v.String() != `{"violation":"none"}` {
+		t.Fatalf("异步回调 content = %v", v.String())
+	}
+	if v := L.GetGlobal("last_err"); v.String() != "nil" {
+		t.Fatalf("成功回调 err 应为 nil（tostring 为 \"nil\"）, got %v", v.String())
+	}
+	if llm.callCount() < 2 {
+		t.Fatalf("LLM 调用次数 = %d, want >= 2", llm.callCount())
+	}
+
+	// 错误路径：Chat 返回错误 → on_chat_response 收到 (req_id, nil, err)
+	llm.setReply("")
+	llm.mu.Lock()
+	llm.err = fmt.Errorf("boom")
+	llm.mu.Unlock()
+	L.DoString(`err_submitted = llm.chat_async("hi", {})`)
+	waitFor(t, func() bool {
+		v := L.GetGlobal("done_count")
+		return v.Type() == lua.LTNumber && float64(v.(lua.LNumber)) >= 2
+	})
+	if !strings.Contains(L.GetGlobal("last_err").String(), "boom") {
+		t.Fatalf("错误回调 err = %v, want 包含 boom", L.GetGlobal("last_err"))
+	}
+}
+
+// ---------- 测试: 真实 redrock_group_manager 插件行为 ----------
+
+func TestRedrockBlackGraySensitive(t *testing.T) {
+	llm := &fakeLLM{reply: `{"violation":"none"}`}
+	pe, adp, _ := newTestEngine(t, llm)
+	L := loadPluginManual(t, pe, "redrock_group_manager")
+
+	// 1. 黑色地带：无本续贷（words/black.txt）→ 消费 + 撤回（第一次违规），不触发 LLM
+	consumed := runOnMessage(t, L, 10001, 20001, "对接全国 无本续贷 一手收单", "90001")
+	if !consumed {
+		t.Fatal("黑色词消息应被消费")
+	}
+	waitFor(t, func() bool { return adp.deletedCount() >= 1 })
+	if llm.callCount() != 0 {
+		t.Fatalf("黑色词不应触发 LLM, calls=%d", llm.callCount())
+	}
+
+	// 2. 敏感地带：操逼（cn_pornographic）→ 消费 + 撤回，不触发 LLM
+	before := adp.deletedCount()
+	consumed = runOnMessage(t, L, 10001, 20002, "你个操逼的", "90002")
+	if !consumed {
+		t.Fatal("敏感词消息应被消费")
+	}
+	waitFor(t, func() bool { return adp.deletedCount() > before })
+	if llm.callCount() != 0 {
+		t.Fatalf("敏感词不应触发 LLM, calls=%d", llm.callCount())
+	}
+
+	// 3. 灰色地带：命中 all.txt 灰色词（考研/加群/资料群）→ 不消费、不立即处罚，异步触发 LLM
+	llm.setReply(`{"violation":"ad","reason":"以资料分享为幌子拉群引流"}`)
+	consumed = runOnMessage(t, L, 10001, 20003, "考研资料群，无偿分享，加群领资料", "90003")
+	if consumed {
+		t.Fatal("灰色词消息不应被消费（先放行）")
+	}
+	waitFor(t, func() bool { return llm.callCount() >= 1 })
+	// 回调（LLM 判 ad）→ 撤回追罚
+	waitFor(t, func() bool { return adp.deletedCount() >= 3 })
+
+	// 4. 灰色地带：LLM 判 none → 不处罚
+	llm.setReply(`{"violation":"none","reason":"正常讨论考研"}`)
+	before = adp.deletedCount()
+	consumed = runOnMessage(t, L, 10001, 20004, "有没有考研上岸的学长学姐", "90004")
+	if consumed {
+		t.Fatal("灰色词消息不应被消费")
+	}
+	time.Sleep(300 * time.Millisecond)
+	if adp.deletedCount() != before {
+		t.Fatalf("LLM 判 none 不应撤回: before=%d after=%d", before, adp.deletedCount())
+	}
+
+	// 5. 豁免：/豁免 20005（管理员）→ 黑色词放行；被禁言用户豁免时自动解除禁言
+	adp.mu.Lock()
+	adp.mutedUsers[20005] = true
+	adp.mu.Unlock()
+	cmdEvent := EventData{
+		PostType: "message", MessageType: "group",
+		GroupID: 10001, UserID: 99999, RawMessage: "/豁免 20005",
+		Admins: []string{"99999"}, MessageID: 1,
+	}
+	consumed, reply, err := pe.commands.Dispatch("/豁免 20005", cmdEvent)
+	if err != nil || !consumed {
+		t.Fatalf("/豁免 派发失败 consumed=%v reply=%q err=%v", consumed, reply, err)
+	}
+	waitFor(t, func() bool {
+		for _, m := range adp.mutedCalls() {
+			if m == "10001:20005:0" {
+				return true
+			}
+		}
+		return false
+	})
+
+	consumed = runOnMessage(t, L, 10001, 20005, "对接全国 无本续贷", "90005")
+	if consumed {
+		t.Fatal("豁免用户发黑色词不应被消费")
+	}
+	waitFor(t, func() bool { return adp.deletedCount() >= 3 })
+	if adp.deletedCount() != 3 {
+		t.Fatalf("豁免用户消息不应被撤回: deleted=%d", adp.deletedCount())
+	}
+
+	// 6. 解除豁免（/取消豁免 别名同样注册）→ 恢复检测
+	cmdEvent.RawMessage = "/解除豁免 20005"
+	consumed, _, err = pe.commands.Dispatch("/解除豁免 20005", cmdEvent)
+	if err != nil || !consumed {
+		t.Fatalf("/解除豁免 派发失败 consumed=%v err=%v", consumed, err)
+	}
+	consumed = runOnMessage(t, L, 10001, 20005, "无本续贷 全国一手收单", "90006")
+	if !consumed {
+		t.Fatal("解除豁免后黑色词应恢复被消费")
+	}
+	waitFor(t, func() bool { return adp.deletedCount() >= 4 })
+
+	// 7. 命令注册完整性
+	for _, cmd := range []string{"/豁免", "/解除豁免", "/取消豁免", "/groupstats"} {
+		if !pe.commands.HasCommand(cmd) {
+			t.Fatalf("命令 %s 未注册", cmd)
+		}
+	}
+}
+
+// 防未使用告警（io 保留给后续扩展）
+var _ = io.Discard

--- a/internal/pluggin/llm_review_test.go
+++ b/internal/pluggin/llm_review_test.go
@@ -137,7 +137,12 @@ func (f *fakeLLM) callCount() int {
 func copyPlugin(t *testing.T, dst string) {
 	t.Helper()
 	src := filepath.Join("..", "..", "..", "Plugins", "plugins", "redrock_group_manager")
-	filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	// 跨仓库端到端测试：Plugins 仓库需与 Bot 同级检出；CI 无此目录时跳过，
+	// Go 侧机制测试（TestLLMInjectSyncAndAsync）仍正常执行。
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		t.Skipf("插件源码目录不存在（需 Plugins 仓库同级检出）: %s", src)
+	}
+	if err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -151,7 +156,9 @@ func copyPlugin(t *testing.T, dst string) {
 			return err
 		}
 		return os.WriteFile(target, data, 0o644)
-	})
+	}); err != nil {
+		t.Fatalf("复制插件目录失败: %v", err)
+	}
 }
 
 func newTestEngine(t *testing.T, llm LLMAccess) (*PluginEngine, *fakeAdapter, string) {

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -177,7 +177,7 @@ type PluginEngine struct {
 	// asyncCh 异步任务完成后的回调队列（runAsyncCallbacks 消费）。
 	asyncCh chan asyncTask
 	// asyncSeq req_id 自增序号。
-	asyncSeq uint64
+	asyncSeq  uint64
 	currentEv EventData
 	commands  *CommandRegistry
 }
@@ -208,19 +208,19 @@ func NewPluginEngine(basePath string, adapter SendAdapter, db *gorm.DB, c *cache
 		basePath = "data/pluggins"
 	}
 	pe := &PluginEngine{
-		plugins:    make(map[string]*LoadedPlugin),
-		basePath:   basePath,
-		adapter:    adapter,
-		db:         db,
-		cache:      c,
-		t2i:        t2i,
-		sandbox:    sb,
-		dao:        d,
-		agentOp:    ag,
-		llmAccess:  llm,
-		asyncAPIs:  make(map[string]*AsyncAPI),
-		asyncCh:    make(chan asyncTask, 128),
-		commands:   NewCommandRegistry(),
+		plugins:   make(map[string]*LoadedPlugin),
+		basePath:  basePath,
+		adapter:   adapter,
+		db:        db,
+		cache:     c,
+		t2i:       t2i,
+		sandbox:   sb,
+		dao:       d,
+		agentOp:   ag,
+		llmAccess: llm,
+		asyncAPIs: make(map[string]*AsyncAPI),
+		asyncCh:   make(chan asyncTask, 128),
+		commands:  NewCommandRegistry(),
 	}
 	// 注册内置异步 API：chat → 插件入口 on_chat_response
 	pe.RegisterAsyncAPI("chat", AsyncAPI{
@@ -2171,11 +2171,14 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 
 // injectLLM 注入 llm 全局表：插件通过 Bot 自身启用的文本模型 Provider 调用 LLM
 // （模型 / 采样参数 / 密钥全部复用 Bot 配置，插件不接触密钥）。
-//  - llm.available() -> boolean                当前是否有可用文本模型
-//  - llm.chat(messages, opts) -> content, err  同步调用（适合命令等低频路径）
-//  - llm.chat_async(messages, opts) -> req_id  异步调用（不阻塞事件循环）
+//   - llm.available() -> boolean                当前是否有可用文本模型
+//   - llm.chat(messages, opts) -> content, err  同步调用（适合命令等低频路径）
+//   - llm.chat_async(messages, opts) -> req_id  异步调用（不阻塞事件循环）
+//
 // messages: 单字符串（role=user）或数组，元素为字符串（role=user）或
-//           {role="system|user|assistant", content="..."}。
+//
+//	{role="system|user|assistant", content="..."}。
+//
 // opts: {temperature=?, max_tokens=?, timeout=?秒}，缺省回退 Bot Provider 配置。
 // chat_async 立即返回 req_id（失败返回 0 并附加错误串）；完成后引擎调用插件
 // 入口函数 on_chat_response(req_id, content, err)，err 为 nil 表示成功。

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -16,9 +16,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"JuanNiang-Neo/internal/adapter"
+	"JuanNiang-Neo/internal/agent/provider"
 
 	lua "github.com/yuin/gopher-lua"
 	"gopkg.in/yaml.v3"
@@ -108,6 +110,15 @@ type ProviderGroupAccess interface {
 	GetActive(id string) bool
 }
 
+// LLMAccess 插件通过此接口调用 Bot 的 LLM：复用 Bot 自身启用的文本模型
+// Provider 及其配置（模型 / 采样参数 / 密钥），插件不接触任何密钥。
+type LLMAccess interface {
+	// Available 当前是否有启用的文本模型 Provider。
+	Available() bool
+	// Chat 调用 Bot 当前启用的文本模型。req 中未设置的采样参数回退到 Bot 配置。
+	Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error)
+}
+
 // MCPGroupAccess 暴露给插件的 MCP 管理接口。
 type MCPGroupAccess interface {
 	ListMCPs() []MCPInfo
@@ -157,28 +168,74 @@ type PluginEngine struct {
 	sandbox   *sandboxcaller.Client
 	dao       *dao.Bundle
 	agentOp   AgentOperator
+	llmAccess LLMAccess
+	// asyncAPIs 异步 API 注册表：kind（如 "chat"）→ 派发规格。xxx_async 类接口
+	// 提交后立即返回 req_id，阻塞操作在独立 goroutine 完成，完成后派发到插件
+	// Lua 入口函数（如 on_chat_response）。注册表集中管理，后续新增
+	// t2i/http/agent 等异步只需注册一个 kind。
+	asyncAPIs map[string]*AsyncAPI
+	// asyncCh 异步任务完成后的回调队列（runAsyncCallbacks 消费）。
+	asyncCh chan asyncTask
+	// asyncSeq req_id 自增序号。
+	asyncSeq uint64
 	currentEv EventData
 	commands  *CommandRegistry
 }
 
-func NewPluginEngine(basePath string, adapter SendAdapter, db *gorm.DB, c *cache.Cache, t2i *t2icaller.Client, sb *sandboxcaller.Client, d *dao.Bundle, ag AgentOperator) *PluginEngine {
+// AsyncAPI 描述一类可异步执行的 API（注册进引擎异步注册表）。
+// 插件侧调用形态：xxx_async(...) 立即返回 req_id，完成后引擎调用插件 Lua
+// 入口函数 Entry：on_xxx_response(req_id, <Encode 返回值...>)，与事件派发互斥。
+type AsyncAPI struct {
+	// Entry 插件侧 Lua 入口函数名，如 "on_chat_response"。
+	Entry string
+	// Encode 在锁内把 Go 结果转成 Lua 返回值（req_id 已由派发器先压入）。
+	// 成功：err 为 nil、result 为业务结果；失败：result 为 nil、err 非 nil。
+	Encode func(L *lua.LState, result any, err error) []lua.LValue
+}
+
+// asyncTask 一次异步调用的完成事件（runAsyncCallbacks 消费）。
+type asyncTask struct {
+	pluginName string
+	kind       string
+	api        *AsyncAPI
+	reqID      uint64
+	result     any
+	err        error
+}
+
+func NewPluginEngine(basePath string, adapter SendAdapter, db *gorm.DB, c *cache.Cache, t2i *t2icaller.Client, sb *sandboxcaller.Client, d *dao.Bundle, ag AgentOperator, llm LLMAccess) *PluginEngine {
 	if basePath == "" {
 		basePath = "data/pluggins"
 	}
 	pe := &PluginEngine{
-		plugins:  make(map[string]*LoadedPlugin),
-		basePath: basePath,
-		adapter:  adapter,
-		db:       db,
-		cache:    c,
-		t2i:      t2i,
-		sandbox:  sb,
-		dao:      d,
-		agentOp:  ag,
-		commands: NewCommandRegistry(),
+		plugins:    make(map[string]*LoadedPlugin),
+		basePath:   basePath,
+		adapter:    adapter,
+		db:         db,
+		cache:      c,
+		t2i:        t2i,
+		sandbox:    sb,
+		dao:        d,
+		agentOp:    ag,
+		llmAccess:  llm,
+		asyncAPIs:  make(map[string]*AsyncAPI),
+		asyncCh:    make(chan asyncTask, 128),
+		commands:   NewCommandRegistry(),
 	}
+	// 注册内置异步 API：chat → 插件入口 on_chat_response
+	pe.RegisterAsyncAPI("chat", AsyncAPI{
+		Entry: "on_chat_response",
+		Encode: func(L *lua.LState, result any, err error) []lua.LValue {
+			if err != nil {
+				return []lua.LValue{lua.LNil, lua.LString(err.Error())}
+			}
+			return []lua.LValue{lua.LString(result.(string)), lua.LNil}
+		},
+	})
 	// 注册内置 /help 命令
 	pe.registerBuiltinCommands()
+	// 异步任务消费者：与事件派发互斥执行 Lua，保证 LState 安全
+	go pe.runAsyncCallbacks()
 	return pe
 }
 
@@ -1046,6 +1103,11 @@ func (pe *PluginEngine) injectBaseAPI(L *lua.LState, pluginName string, permissi
 	// Agent
 	if hasPerm("agent") && pe.dao != nil {
 		pe.injectAgent(L)
+	}
+
+	// LLM：调用 Bot 自身 LLM（复用 Bot Provider 配置，需要 llm 权限）
+	if hasPerm("llm") && pe.llmAccess != nil {
+		pe.injectLLM(L, pluginName)
 	}
 
 	// File：插件目录内文本文件读写（需要 file 权限）
@@ -2103,6 +2165,192 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 
 	L.SetFuncs(agentTable, funcs)
 	L.SetGlobal("agent", agentTable)
+}
+
+// ---------- LLM ----------
+
+// injectLLM 注入 llm 全局表：插件通过 Bot 自身启用的文本模型 Provider 调用 LLM
+// （模型 / 采样参数 / 密钥全部复用 Bot 配置，插件不接触密钥）。
+//  - llm.available() -> boolean                当前是否有可用文本模型
+//  - llm.chat(messages, opts) -> content, err  同步调用（适合命令等低频路径）
+//  - llm.chat_async(messages, opts) -> req_id  异步调用（不阻塞事件循环）
+// messages: 单字符串（role=user）或数组，元素为字符串（role=user）或
+//           {role="system|user|assistant", content="..."}。
+// opts: {temperature=?, max_tokens=?, timeout=?秒}，缺省回退 Bot Provider 配置。
+// chat_async 立即返回 req_id（失败返回 0 并附加错误串）；完成后引擎调用插件
+// 入口函数 on_chat_response(req_id, content, err)，err 为 nil 表示成功。
+// 派发规格由异步注册表（kind "chat"）定义，见 RegisterAsyncAPI。
+func (pe *PluginEngine) injectLLM(L *lua.LState, pluginName string) {
+	llmTable := L.NewTable()
+	funcs := map[string]lua.LGFunction{
+		"available": func(L *lua.LState) int {
+			L.Push(lua.LBool(pe.llmAccess != nil && pe.llmAccess.Available()))
+			return 1
+		},
+		"chat": func(L *lua.LState) int {
+			req, err := luaChatRequest(L, 1, 2)
+			if err != nil {
+				L.Push(lua.LNil)
+				L.Push(lua.LString(err.Error()))
+				return 2
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), llmTimeoutFromOpts(L, 2))
+			defer cancel()
+			resp, err := pe.llmAccess.Chat(ctx, req)
+			if err != nil {
+				L.Push(lua.LNil)
+				L.Push(lua.LString(err.Error()))
+				return 2
+			}
+			L.Push(lua.LString(resp.Message.Content))
+			return 1
+		},
+		"chat_async": func(L *lua.LState) int {
+			req, err := luaChatRequest(L, 1, 2)
+			if err != nil {
+				L.Push(lua.LNumber(0))
+				L.Push(lua.LString(err.Error()))
+				return 2
+			}
+			run := func(ctx context.Context) (any, error) {
+				resp, err := pe.llmAccess.Chat(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return resp.Message.Content, nil
+			}
+			id, err := pe.submitAsync(pluginName, "chat", llmTimeoutFromOpts(L, 2), run)
+			if err != nil {
+				L.Push(lua.LNumber(0))
+				L.Push(lua.LString(err.Error()))
+				return 2
+			}
+			// req_id 为 uint64；Lua number 在 2^53 内精确，实际序列号远达不到
+			L.Push(lua.LNumber(id))
+			return 1
+		},
+	}
+	L.SetFuncs(llmTable, funcs)
+	L.SetGlobal("llm", llmTable)
+}
+
+// RegisterAsyncAPI 注册一类异步 API（如 "chat" → 插件入口 on_chat_response）。
+// 注册表集中管理 xxx_async 类接口的派发规格，后续新增 t2i/http/agent 等异步
+// 只需注册一个 kind。重复注册 panic（内置 kind 在 NewPluginEngine 注册）。
+func (pe *PluginEngine) RegisterAsyncAPI(kind string, api AsyncAPI) {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+	if _, dup := pe.asyncAPIs[kind]; dup {
+		panic("pluggin: 异步 API 重复注册: " + kind)
+	}
+	pe.asyncAPIs[kind] = &api
+}
+
+// submitAsync 提交一个异步任务：run 在独立 goroutine 中执行（不得触碰任何 LState），
+// 完成后派发到插件的 Entry 入口函数。返回 req_id；kind 未注册返回 error。
+func (pe *PluginEngine) submitAsync(pluginName, kind string, timeout time.Duration, run func(ctx context.Context) (any, error)) (uint64, error) {
+	pe.mu.RLock()
+	api, ok := pe.asyncAPIs[kind]
+	pe.mu.RUnlock()
+	if !ok {
+		return 0, fmt.Errorf("pluggin: 异步 API %q 未注册", kind)
+	}
+	id := atomic.AddUint64(&pe.asyncSeq, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		result, err := run(ctx)
+		pe.asyncCh <- asyncTask{pluginName: pluginName, kind: kind, api: api, reqID: id, result: result, err: err}
+	}()
+	return id, nil
+}
+
+// runAsyncCallbacks 消费异步任务队列，串行派发到插件 Lua 入口函数
+// on_<kind>_response(req_id, <Encode 返回值...>)。与事件派发通过 pe.mu
+// 互斥（写锁），保证同一 LState 不会并发执行 Lua。插件已卸载则丢弃任务。
+func (pe *PluginEngine) runAsyncCallbacks() {
+	for task := range pe.asyncCh {
+		pe.mu.Lock()
+		p, ok := pe.plugins[task.pluginName]
+		if ok {
+			L := p.State
+			fn := L.GetGlobal(task.api.Entry)
+			if fn.Type() == lua.LTFunction {
+				vals := task.api.Encode(L, task.result, task.err)
+				L.Push(fn)
+				L.Push(lua.LNumber(task.reqID))
+				for _, v := range vals {
+					L.Push(v)
+				}
+				if err := L.PCall(1+len(vals), 0, nil); err != nil {
+					log.Error("插件异步回调错误", "plugin", task.pluginName, "kind", task.kind, "err", err)
+				}
+			}
+		}
+		pe.mu.Unlock()
+	}
+}
+
+// luaChatRequest 将 Lua 参数转换为 provider.ChatRequest。
+func luaChatRequest(L *lua.LState, msgIdx int, optsIdx int) (provider.ChatRequest, error) {
+	var req provider.ChatRequest
+	v := L.Get(msgIdx)
+	switch v.Type() {
+	case lua.LTString:
+		req.Messages = []provider.ChatMessage{{Role: "user", Content: v.String()}}
+	case lua.LTTable:
+		tbl := v.(*lua.LTable)
+		tbl.ForEach(func(_, val lua.LValue) {
+			switch val.Type() {
+			case lua.LTString:
+				req.Messages = append(req.Messages, provider.ChatMessage{Role: "user", Content: val.String()})
+			case lua.LTTable:
+				item := val.(*lua.LTable)
+				role := lvString(item.RawGetString("role"), "user")
+				content := lvString(item.RawGetString("content"), "")
+				req.Messages = append(req.Messages, provider.ChatMessage{Role: role, Content: content})
+			}
+		})
+	default:
+		return req, fmt.Errorf("llm: messages 参数必须是字符串或数组")
+	}
+	if len(req.Messages) == 0 {
+		return req, fmt.Errorf("llm: messages 不能为空")
+	}
+	if opts := L.Get(optsIdx); opts.Type() == lua.LTTable {
+		ot := opts.(*lua.LTable)
+		if t := ot.RawGetString("temperature"); t.Type() == lua.LTNumber {
+			req.Temperature = float32(t.(lua.LNumber))
+		}
+		if mt := ot.RawGetString("max_tokens"); mt.Type() == lua.LTNumber {
+			req.MaxTokens = int(mt.(lua.LNumber))
+		}
+	}
+	return req, nil
+}
+
+// lvString 取 Lua 字符串/数字值，缺省回退 def。
+func lvString(v lua.LValue, def string) string {
+	switch v.Type() {
+	case lua.LTString:
+		return string(v.(lua.LString))
+	case lua.LTNumber:
+		return strconv.FormatFloat(float64(v.(lua.LNumber)), 'f', -1, 64)
+	}
+	return def
+}
+
+// llmTimeoutFromOpts 从 opts.timeout（秒）解析调用超时，缺省 60s。
+func llmTimeoutFromOpts(L *lua.LState, optsIdx int) time.Duration {
+	timeout := 60 * time.Second
+	if opts := L.Get(optsIdx); opts.Type() == lua.LTTable {
+		if t := opts.(*lua.LTable).RawGetString("timeout"); t.Type() == lua.LTNumber {
+			if sec := float64(t.(lua.LNumber)); sec > 0 {
+				timeout = time.Duration(sec * float64(time.Second))
+			}
+		}
+	}
+	return timeout
 }
 
 // ====================================================================

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -1655,6 +1655,54 @@ func (pe *PluginEngine) injectCache(L *lua.LState, pluginName string) {
 
 // ---------- T2I ----------
 
+// luaTableToT2IOptions 解析 t2i.generate / t2i.generate_url 的可选 options 表
+// （键名与 T2I 服务 GenerateOptions 的 JSON 字段一致）；未传或为 nil 时返回 nil。
+// 未知键返回错误，便于插件尽早发现拼写问题。
+func luaTableToT2IOptions(L *lua.LState, idx int) (*t2icaller.GenerateOptions, error) {
+	if L.Get(idx) == lua.LNil {
+		return nil, nil
+	}
+	tbl := L.CheckTable(idx)
+	opts := &t2icaller.GenerateOptions{}
+	var parseErr error
+	tbl.ForEach(func(k, v lua.LValue) {
+		if parseErr != nil {
+			return
+		}
+		switch lua.LVAsString(k) {
+		case "type":
+			opts.Type = t2icaller.ImageType(lua.LVAsString(v))
+		case "quality":
+			opts.Quality = int(lua.LVAsNumber(v))
+		case "omit_background":
+			opts.OmitBackground = lua.LVAsBool(v)
+		case "full_page":
+			fp := lua.LVAsBool(v)
+			opts.FullPage = &fp
+		case "viewport_width":
+			opts.ViewportWidth = int(lua.LVAsNumber(v))
+		case "viewport_height":
+			opts.ViewportHeight = int(lua.LVAsNumber(v))
+		case "scale":
+			opts.Scale = lua.LVAsString(v)
+		case "animations":
+			opts.Animations = t2icaller.Animation(lua.LVAsString(v))
+		case "caret":
+			opts.Caret = t2icaller.Caret(lua.LVAsString(v))
+		case "device_scale_factor_level":
+			opts.DeviceScaleFactor = t2icaller.ScaleLevel(lua.LVAsString(v))
+		case "timeout":
+			opts.Timeout = float64(lua.LVAsNumber(v))
+		default:
+			parseErr = fmt.Errorf("未知 T2I 选项: %s", lua.LVAsString(k))
+		}
+	})
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return opts, nil
+}
+
 func (pe *PluginEngine) injectT2I(L *lua.LState, pluginName string) {
 	t2iTable := L.NewTable()
 
@@ -1675,9 +1723,16 @@ func (pe *PluginEngine) injectT2I(L *lua.LState, pluginName string) {
 				return 2
 			}
 			html := L.CheckString(1)
+			opts, optErr := luaTableToT2IOptions(L, 2)
+			if optErr != nil {
+				L.Push(lua.LNil)
+				L.Push(lua.LString(optErr.Error()))
+				return 2
+			}
 			resp, err := client.Generate(context.Background(), t2icaller.GenerateRequest{
-				HTML:   html,
-				AsJSON: true,
+				HTML:    html,
+				AsJSON:  true,
+				Options: opts,
 			})
 			if err != nil {
 				L.Push(lua.LNil)
@@ -1695,9 +1750,16 @@ func (pe *PluginEngine) injectT2I(L *lua.LState, pluginName string) {
 				return 2
 			}
 			html := L.CheckString(1)
+			opts, optErr := luaTableToT2IOptions(L, 2)
+			if optErr != nil {
+				L.Push(lua.LNil)
+				L.Push(lua.LString(optErr.Error()))
+				return 2
+			}
 			url, err := client.GenerateURL(context.Background(), t2icaller.GenerateRequest{
-				HTML:   html,
-				AsJSON: true,
+				HTML:    html,
+				AsJSON:  true,
+				Options: opts,
 			})
 			if err != nil {
 				L.Push(lua.LNil)

--- a/internal/pluggin/pluggin_test.go
+++ b/internal/pluggin/pluggin_test.go
@@ -3,6 +3,7 @@ package pluggin
 import (
 	"testing"
 
+	t2icaller "JuanNiang-Neo/infrastructure/t2i/handler"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -48,5 +49,62 @@ func TestGoToLuaValueStringSlice(t *testing.T) {
 	}
 	if inner.Len() != 2 {
 		t.Fatalf("嵌套 []string 长度 = %d, want 2", inner.Len())
+	}
+}
+
+// TestLuaTableToT2IOptions 回归：t2i.generate/generate_url 可选 options 表解析。
+func TestLuaTableToT2IOptions(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	// 未传（栈上为 nil）→ (nil, nil)，等价于不指定 options
+	L.Push(lua.LNil)
+	opts, err := luaTableToT2IOptions(L, 1)
+	L.Pop(1)
+	if err != nil || opts != nil {
+		t.Fatalf("nil options 应返回 (nil, nil), got (%v, %v)", opts, err)
+	}
+
+	// 完整 options 表
+	tbl := L.NewTable()
+	tbl.RawSetString("type", lua.LString("png"))
+	tbl.RawSetString("quality", lua.LNumber(90))
+	tbl.RawSetString("omit_background", lua.LBool(true))
+	tbl.RawSetString("full_page", lua.LBool(false))
+	tbl.RawSetString("viewport_width", lua.LNumber(261))
+	tbl.RawSetString("viewport_height", lua.LNumber(379))
+	tbl.RawSetString("scale", lua.LString("device"))
+	tbl.RawSetString("animations", lua.LString("disabled"))
+	tbl.RawSetString("caret", lua.LString("hide"))
+	tbl.RawSetString("device_scale_factor_level", lua.LString("ultra"))
+	tbl.RawSetString("timeout", lua.LNumber(30))
+	L.Push(tbl)
+	opts, err = luaTableToT2IOptions(L, 1)
+	L.Pop(1)
+	if err != nil {
+		t.Fatalf("解析 options 失败: %v", err)
+	}
+	if opts.Type != t2icaller.ImageTypePNG ||
+		opts.Quality != 90 ||
+		!opts.OmitBackground ||
+		opts.FullPage == nil || *opts.FullPage ||
+		opts.ViewportWidth != 261 ||
+		opts.ViewportHeight != 379 ||
+		opts.Scale != "device" ||
+		opts.Animations != t2icaller.AnimationDisabled ||
+		opts.Caret != t2icaller.CaretHide ||
+		opts.DeviceScaleFactor != t2icaller.ScaleUltra ||
+		opts.Timeout != 30 {
+		t.Fatalf("options 解析结果不符合预期: %+v", opts)
+	}
+
+	// 未知键 → 返回错误，避免拼写问题静默吞掉
+	tbl2 := L.NewTable()
+	tbl2.RawSetString("bogus", lua.LBool(true))
+	L.Push(tbl2)
+	_, err = luaTableToT2IOptions(L, 1)
+	L.Pop(1)
+	if err == nil {
+		t.Fatal("未知选项键应报错")
 	}
 }

--- a/internal/pluggin/sdk/jn.lua
+++ b/internal/pluggin/sdk/jn.lua
@@ -145,9 +145,21 @@ M.cache = cache
 -- t2i 文生图 (需要 t2i 权限)
 -- ====================================================================
 
+--- generate / generate_url 的可选 options 表（键名与 T2I 服务 GenerateOptions 的 JSON 字段一致）：
+---   type                      string   图片格式 "jpeg" | "png"（默认 png）
+---   quality                   number   压缩质量（仅 jpeg 有效）
+---   omit_background           boolean  透明背景（png）
+---   full_page                 boolean  整页截图（默认 true；false 时按 viewport 尺寸截图）
+---   viewport_width            number   视口宽度（px）
+---   viewport_height           number   视口高度（px）
+---   scale                     string   "css" | "device"
+---   animations                string   "allow" | "disabled"
+---   caret                     string   "hide" | "initial"
+---   device_scale_factor_level string   "normal" | "high" | "ultra"
+---   timeout                   number   渲染超时（秒）
 ---@class jn.T2I
----@field generate fun(html: string): string, string? 生成图片，返回图片 ID
----@field generate_url fun(html: string): string, string? 生成图片，返回 URL
+---@field generate fun(html: string, options?: table): string, string? 生成图片，返回图片 ID
+---@field generate_url fun(html: string, options?: table): string, string? 生成图片，返回 URL
 ---@field toggle fun(active: boolean): boolean, string? 启用/停用 T2I 服务
 ---@field is_active fun(): boolean
 ---@field get_config fun(): table, string?

--- a/internal/pluggin/sdk/jn.lua
+++ b/internal/pluggin/sdk/jn.lua
@@ -232,6 +232,26 @@ M.sandbox = sandbox
 M.agent = agent
 
 -- ====================================================================
+-- llm LLM 调用 (需要 llm 权限)
+-- ====================================================================
+-- 通过 Bot 自身启用的文本模型 Provider 调用 LLM：模型 / 采样参数 / 密钥
+-- 全部复用 Bot 配置，插件不接触任何密钥。适合内容审查等二次判断场景。
+-- 高频路径请使用 chat_async（异步，不阻塞事件循环与其它插件）。
+
+---@class jn.LLM
+---@field available fun(): boolean 当前是否有可用的文本模型 Provider
+---@field chat fun(messages: string|table, opts?: table): string?, string? 同步调用，返回 (content, err)；适合命令等低频路径
+---@field chat_async fun(messages: string|table, opts?: table): number 异步提交，立即返回 req_id（失败返回 0）；完成后引擎调用插件入口 on_chat_response(req_id, content, err)
+---@field messages table 消息参数：单字符串（role=user）或数组，元素为字符串（role=user）或 {role="system|user|assistant", content="..."}
+---@field opts table 选项：{temperature=?, max_tokens=?, timeout=?秒}，缺省回退 Bot Provider 配置（默认超时 60s）
+---
+--- 异步回调约定（引擎级异步注册表，kind "chat"）：
+--- 插件定义全局函数 on_chat_response(req_id, content, err)，引擎在 LLM 返回后
+--- 串行调用（与事件派发互斥）。err 为 nil 表示成功；req_id 与 chat_async 的
+--- 返回值一致，可用于关联请求上下文（如查表取回本次审查的事件/关键词）。
+M.llm = llm
+
+-- ====================================================================
 -- config 动态配置 (无需权限，默认注入)
 -- ====================================================================
 


### PR DESCRIPTION
## 变更

本 PR 包含两块能力：

### 1. `t2i.generate` / `t2i.generate_url` 可选 `options` 表

新增可选第二参数 `options` 表，键名与 T2I 服务 `GenerateOptions` 的 JSON 字段一致：

```lua
t2i.generate_url(html, {
    viewport_width = 615,
    viewport_height = 379,
    full_page = false,
})
```

支持键：`type` / `quality` / `omit_background` / `full_page` / `viewport_width` / `viewport_height` / `scale` / `animations` / `caret` / `device_scale_factor_level` / `timeout`。未知键返回错误，便于插件尽早发现拼写问题。不传 `options` 时行为与之前完全一致，向后兼容。

### 2. `jn.llm` 异步 API 注册表

新增插件 `llm` 权限与 `jn.llm` 全局表，复用 Bot 自身文本 Provider（模型/采样/密钥全部走 Bot 配置，插件不接触密钥）：

- `llm.available()` / `llm.chat(messages, opts)`（同步，命令等低频路径）
- `llm.chat_async(messages, opts) -> req_id`（异步，不阻塞事件循环；完成后引擎派发插件入口 `on_chat_response(req_id, content, err)`）
- 引擎级**异步注册表** `RegisterAsyncAPI(kind, {Entry, Encode})`：阻塞操作在独立 goroutine 完成，结果经队列串行派发（与事件派发互斥，LState 安全），插件卸载自动丢弃；后续 t2i/http/agent 异步只需注册一个 kind
- `adapter.GroupMemberInfo` 新增 `shut_up_timestamp`（豁免自动解禁用）

## 动机

- 猜单词棋盘按单词长度精确下发画布尺寸（viewport + full_page=false），避免窄棋盘大面积空白——此前 Lua 侧无法传递渲染选项
- 插件内容审查等二次判断场景的高频路径不能阻塞事件循环——`chat_async` + 注册表派发解决

## 验证

- `go build ./...` 通过
- `TestLuaTableToT2IOptions`：覆盖 nil / 全量字段解析 / 未知键报错
- `TestLLMInjectSyncAndAsync` + `TestRedrockBlackGraySensitive`：jn.llm 同步/异步回调与红岩插件黑灰敏感端到端
- `go test ./internal/pluggin/` 通过

## 配套插件

JuanNiangDev/JuanNiang-Plugins：

- `redrock_caidanci_grade` 棋盘渲染优化依赖 t2i options 能力
- `redrock_group_manager` 灰色地带 LLM 审查依赖 jn.llm

## 说明

- T2I 未在真实服务上端到端验证（本地无服务）
