### PR TITLE
fix(agent): ban_group_member 工具描述注明 0 表示解除禁言

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -285,7 +285,7 @@ jn.onebot11.send_group_msg(123456, {
 | 函数 | 说明 |
 |------|------|
 | `onebot11.kick_group_member(group_id, user_id [, reject_add]) → bool [, err]` | reject_add 默认 false |
-| `onebot11.ban_group_member(group_id, user_id, duration) → bool [, err]` | duration 秒 |
+| `onebot11.ban_group_member(group_id, user_id, duration) → bool [, err]` | duration 秒，0 表示解除禁言 |
 | `onebot11.set_group_whole_ban(group_id, enable) → bool [, err]` | 全员禁言开关 |
 | `onebot11.set_group_card(group_id, user_id, card) → bool [, err]` | 设群名片 |
 

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -517,7 +517,7 @@ func RegisterBuiltinTools(
 				"properties": map[string]any{
 					"group_id": map[string]any{"type": "integer", "description": "群号"},
 					"user_id":  map[string]any{"type": "integer", "description": "目标用户 QQ 号"},
-					"duration": map[string]any{"type": "integer", "description": "禁言时长(秒)"},
+					"duration": map[string]any{"type": "integer", "description": "禁言时长(秒)，0 表示解除禁言"},
 				},
 				"required": []string{"group_id", "user_id", "duration"},
 			}, true, false),
@@ -530,6 +530,9 @@ func RegisterBuiltinTools(
 			json.Unmarshal(args, &p)
 			if err := adapter.BanGroupMember(p.GroupID, p.UserID, p.Duration); err != nil {
 				return "", err
+			}
+			if p.Duration == 0 {
+				return fmt.Sprintf("已将 %d 解除禁言（群 %d）", p.UserID, p.GroupID), nil
 			}
 			return fmt.Sprintf("已将 %d 禁言 %d 秒", p.UserID, p.Duration), nil
 		},


### PR DESCRIPTION
## 变更

- `ban_group_member` 工具 schema 的 duration 描述补充「0 表示解除禁言」，避免 LLM 误以为 0 不可用而拒绝解除禁言请求
- duration=0 时执行成功文案改为「已将 X 解除禁言（群 Y）」
- `docs/plugin-development.md` 同步补充

## 背景

用户实测：解除禁言时 bot 回复「把禁言时间设置为 0 不可用」。OneBot11 规范中 `set_group_ban.duration=0` 即为取消禁言，工具描述缺失导致 LLM 无法正确使用该语义。

## 验证
- `go test ./internal/agent/tool/` PASS
- `go build ./...` 通过