### PR TITLE
fix(fishcal): 显式传递 T2I 渲染视口，消除日历右侧空白

### DIFF
--- a/internal/agent/fishcal/fishcal.go
+++ b/internal/agent/fishcal/fishcal.go
@@ -29,6 +29,15 @@ import (
 
 var log = logging.NewModule("fishcal")
 
+// 日历画布尺寸：模板 .page 与 T2I 渲染视口必须一致（GenerateImage 显式传 ViewportWidth/Height），
+// 否则渲染器用默认视口宽（如 800）会把 682 宽的画布左对齐排出右侧空白。
+const (
+	fishCalCanvasWidth  = 682
+	fishCalCanvasHeight = 757
+)
+
+func ptrBool(b bool) *bool { return &b }
+
 //go:embed fonts/lxgwwenkai-regular.woff2
 var wenkaiFonts embed.FS
 
@@ -139,8 +148,11 @@ func (s *Scheduler) TriggerNow(ctx context.Context) error {
 	img, err := t2i.GenerateImage(ctx, t2icaller.GenerateRequest{
 		HTML: html,
 		Options: &t2icaller.GenerateOptions{
-			Type:    t2icaller.ImageTypeJPEG,
-			Quality: 85,
+			Type:           t2icaller.ImageTypeJPEG,
+			Quality:        85,
+			ViewportWidth:  fishCalCanvasWidth,
+			ViewportHeight: fishCalCanvasHeight,
+			FullPage:       ptrBool(false),
 		},
 	})
 	if err != nil {
@@ -262,7 +274,7 @@ func buildCalendarHTML(t time.Time, affair string) string {
 <style>
 %s
 html,body{margin:0;padding:0;}
-.page{position:relative;width:682px;height:757px;box-sizing:border-box;background:#f7f4ec;overflow:hidden;font-family:'LXGW WenKai','KaiTi','STKaiti','SimSun',serif;color:#2b2b2b;}
+.page{position:relative;width:%dpx;height:%dpx;box-sizing:border-box;background:#f7f4ec;overflow:hidden;font-family:'LXGW WenKai','KaiTi','STKaiti','SimSun',serif;color:#2b2b2b;}
 .frame{position:absolute;inset:22px;border:1px solid #2b2b2b;padding:26px 40px 18px;display:flex;flex-direction:column;}
 .header{text-align:center;}
 h1{margin:0;font-size:46px;font-weight:700;letter-spacing:12px;}
@@ -326,6 +338,7 @@ h1{margin:0;font-size:46px;font-weight:700;letter-spacing:12px;}
 </div>
 </div>`,
 		buildFontFaces(),
+		fishCalCanvasWidth, fishCalCanvasHeight,
 		solarMonthCN[int(t.Month())-1], fmt.Sprintf("%02d", t.Day()),
 		weekdayCN[int(t.Weekday())], lunarStr,
 		weekendLine, holidayLine,

--- a/internal/agent/tool/eino_tool_test.go
+++ b/internal/agent/tool/eino_tool_test.go
@@ -11,8 +11,8 @@ import (
 func TestBuildEinoToolsSkipsUnavailable(t *testing.T) {
 	registry := NewToolRegistry()
 
-	ok := &onebotTool{BaseTool: NewTool("", "ok_tool", "可用工具", openai.FunctionParameters{"type": "object"}, true, false)}
-	bad := &onebotTool{BaseTool: NewTool("", "bad_tool", "服务已停用", openai.FunctionParameters{"type": "object"}, true, false)}
+	ok := &onebotTool{BaseTool: NewTool(NewToolInput{id: "", name: "ok_tool", desc: "可用工具", params: openai.FunctionParameters{"type": "object"}, builtin: true})}
+	bad := &onebotTool{BaseTool: NewTool(NewToolInput{id: "", name: "bad_tool", desc: "服务已停用", params: openai.FunctionParameters{"type": "object"}, builtin: true})}
 	bad.SetAvailable(func() bool { return false }) // 模拟 T2I/Sandbox 未启用
 
 	registry.Register(ok)
@@ -30,7 +30,7 @@ func TestBuildEinoToolsSkipsUnavailable(t *testing.T) {
 
 // TestIsAvailableDefault 验证未设置可用性回调的工具默认始终可用。
 func TestIsAvailableDefault(t *testing.T) {
-	bt := NewTool("", "plain", "普通工具", openai.FunctionParameters{"type": "object"}, true, false)
+	bt := NewTool(NewToolInput{id: "", name: "plain", desc: "普通工具", params: openai.FunctionParameters{"type": "object"}, builtin: true})
 	if !bt.IsAvailable() {
 		t.Error("未设置 available 的工具应始终可用")
 	}


### PR DESCRIPTION
## 问题

合并后生产渲染的摸鱼日历图片为 **800×757**，右侧约 140px 空白（实测用户截图：内容只覆盖 x=22..659）。

## 根因

`TriggerNow` 调 `GenerateImage` 只传了 `Type/Quality`，没传视口尺寸。T2I 服务按**默认视口宽 800** 渲染，682 宽的新画布被左对齐排进 800 宽视口 → 输出 800 宽、右侧空白。旧模板 root 恰好 800 宽，被默认视口掩盖了该问题。

## 修复

- 画布尺寸抽成 `fishCalCanvasWidth/Height` 常量（682×757）
- `GenerateImage` 显式传 `ViewportWidth/ViewportHeight` + `full_page=false`
- 模板 `.page` 与视口共用同一常量，防再漂移

方案与 `redrock_caidanci_grade` 插件的自定义尺寸做法一致（`viewport_width/viewport_height`），该插件生产环境已验证此字段有效。

## 验证

- 682×757 视口渲染：内容铺满，右侧仅 frame 内边距 22px（正常）
- 800 宽视口复现旧问题：140px 空白（与线上截图一致）
- `go test ./internal/agent/fishcal/` + `go vet` + gofmt 全过

## 注意

- 本机无 T2I 服务，未端到端验证真实服务端行为；但字段契约（models.go 的 `viewport_width/viewport_height`）与生产插件用法一致