### PR TITLE
fix(pluggin): 统一 currentEv 更新并解耦内置命令与插件加载状态

### DIFF
--- a/internal/pluggin/command.go
+++ b/internal/pluggin/command.go
@@ -21,6 +21,7 @@ type CommandHandler func(args []string, event EventData) (consumed bool, reply s
 type CommandOpts struct {
 	Description string // 一句话描述
 	Usage       string // 用法示例（如 "/system provider switch <id>"）
+	Builtin     bool   // 内置命令（纯 Go 闭包，不触碰 LState，不依赖插件加载状态）
 }
 
 // CommandNode 命令树节点。叶节点（Handler != nil）可执行；非叶节点仅作为分组。
@@ -29,6 +30,7 @@ type CommandNode struct {
 	Opts       CommandOpts
 	Handler    CommandHandler
 	PluginName string // 注册该命令的插件名
+	Builtin    bool   // 内置命令标记（见 CommandOpts.Builtin），随 Handler 一并更新
 	Children   map[string]*CommandNode
 }
 
@@ -70,6 +72,7 @@ func (r *CommandRegistry) Register(plugin string, path []string, opts CommandOpt
 			next.Opts = opts
 			next.Handler = handler
 			next.PluginName = plugin
+			next.Builtin = opts.Builtin
 		}
 		cur = next
 	}

--- a/internal/pluggin/deadlock_test.go
+++ b/internal/pluggin/deadlock_test.go
@@ -268,6 +268,27 @@ end
 	waitFor(t, func() bool { return hasGroupMsg(adp, "inflight-done") })
 }
 
+// TestBuiltinHelpNotRequireSystemPlugin 内置 /help 命令的执行不依赖 system 插件
+// 是否加载（handler 是纯 Go 闭包，不触碰 LState）。修复前 execCommand 按
+// pluginByName(node.PluginName) 查找，system 未加载时 /help 静默不可用。
+func TestBuiltinHelpNotRequireSystemPlugin(t *testing.T) {
+	pe, _ := newMiniTestEngine(t, nil) // 未加载任何插件（含 system）
+	ev := EventData{PostType: "message", MessageType: "group", UserID: 1, GroupID: 2}
+
+	c, reply, err := dispatchCommand(pe, "/help", ev)
+	if err != nil || !c {
+		t.Fatalf("/help 应被消费且无错误, got (consumed=%v, err=%v)", c, err)
+	}
+	if !strings.Contains(reply, "可用命令") {
+		t.Fatalf("/help 应返回帮助文本, got %q", reply)
+	}
+
+	// 内置命令不参与插件命令列表（无插件归属）
+	if pe.commands.HasCommand("/help") == false {
+		t.Fatal("/help 应存在于命令注册表")
+	}
+}
+
 // TestExecCommandSkipsUnloadedPlugin execCommand 安全分支：命令已匹配但插件
 // 已卸载（Match 与执行之间的 Unload 窗口）→ 不执行 handler、不 panic。
 func TestExecCommandSkipsUnloadedPlugin(t *testing.T) {
@@ -307,7 +328,7 @@ function on_message(event)
     local ok1, err1 = jn.onebot11.delete_msg("90001")
     local ok2, err2 = jn.onebot11.ban_group_member(12345, 67890, 60)
     local ok3, err3 = jn.onebot11.kick_group_member(12345, 67890, false)
-    assert(ok1 == true and ok2 == true and ok3 == true, "同步 API 应返回 true: " .. tostring(err1) .. tostring(err2) .. tostring(err3))
+    assert(ok1 == true and err1 == nil and ok2 == true and err2 == nil and ok3 == true and err3 == nil, "同步 API 应返回 (true, nil): " .. tostring(err1) .. tostring(err2) .. tostring(err3))
     return false, nil
 end
 `)

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -347,10 +347,12 @@ func (pe *PluginEngine) IsSystem(name string) bool {
 }
 
 // registerBuiltinCommands 注册内置命令（/help）。
+// Builtin 标记：handler 是纯 Go 闭包（不触碰 LState），执行不依赖 system 插件加载状态。
 func (pe *PluginEngine) registerBuiltinCommands() {
 	pe.commands.Register("system", []string{"help"}, CommandOpts{
 		Description: "查看所有可用命令，或查看某个命令的子命令与用法",
 		Usage:       "/help [命令路径...]",
+		Builtin:     true,
 	}, func(args []string, event EventData) (bool, string, error) {
 		// /help 或 /help <cmd> [sub...]
 		reply := pe.commands.FormatHelp(args)
@@ -789,9 +791,12 @@ func (pe *PluginEngine) pluginByName(name string) *LoadedPlugin {
 // execCommand 在插件 stateMu 下执行命令 handler（保证 LState 串行，且不再持有
 // pe.mu / commands 锁——handler 内动态注册命令不会触发读锁升级写锁死锁）。
 // 插件未加载/已卸载时**不执行**：命令 handler 闭包捕获插件 LState，若插件已被
-// Unload 关闭（Match 与执行之间存在窗口），执行会 panic。内置命令（/help）
-// 注册在 system 插件名下，正常总是加载（内嵌资源），此处不执行只影响极端场景。
+// Unload 关闭（Match 与执行之间存在窗口），执行会 panic。
+// 内置命令（Builtin）是纯 Go 闭包，不触碰 LState，直接执行、不依赖插件加载状态。
 func (pe *PluginEngine) execCommand(node *CommandNode, args []string, event EventData) (bool, string, error) {
+	if node.Builtin {
+		return node.Handler(args, event)
+	}
 	p := pe.pluginByName(node.PluginName)
 	if p == nil {
 		return false, "", nil

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -716,6 +716,8 @@ func (pe *PluginEngine) RouteWebhook(pluginName string, path string, method stri
 
 // OnNotice 通知事件（群成员增减、禁言、文件上传等）。
 func (pe *PluginEngine) OnNotice(event EventData) {
+	// 更新当前事件（与 Dispatch 派发路径一致）
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
@@ -739,6 +741,8 @@ func (pe *PluginEngine) OnNotice(event EventData) {
 
 // OnRequest 请求事件（加好友、加群邀请）。
 func (pe *PluginEngine) OnRequest(event EventData) {
+	// 更新当前事件（与 Dispatch 派发路径一致）
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
@@ -986,6 +990,9 @@ func (pe *PluginEngine) dispatchMessage(ev adapter.Event) DispatchResult {
 // pluginIDs 指定要通知的插件目录名列表（与 map key / p.Dir 目录名一致，
 // 不是 Manifest.Name 显示名）；为空则通知所有插件。
 func (pe *PluginEngine) onCronJob(event EventData, pluginIDs []string) bool {
+	// 更新当前事件：插件回调内 jn.agent.get_current_chat_area / compact_memory
+	// 应观察到当前派发的事件，而不是上一个消息事件
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		// 按 CronJob 配置的插件列表过滤
 		if len(pluginIDs) > 0 && !containsString(pluginIDs, filepath.Base(p.Dir)) {
@@ -1031,6 +1038,8 @@ func containsString(list []string, target string) bool {
 
 // onNotice 派发 notice 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onNotice(event EventData) bool {
+	// 更新当前事件（见 onCronJob 注释）
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
@@ -1062,6 +1071,8 @@ func (pe *PluginEngine) onNotice(event EventData) bool {
 
 // onRequest 派发 request 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onRequest(event EventData) bool {
+	// 更新当前事件（见 onCronJob 注释）
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
@@ -1093,6 +1104,8 @@ func (pe *PluginEngine) onRequest(event EventData) bool {
 
 // onWebhook 派发 webhook 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onWebhook(event EventData) (consumed bool, reply string) {
+	// 更新当前事件（见 onCronJob 注释）
+	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		if !p.HasPermission("webhook") {
 			continue


### PR DESCRIPTION
## 变更内容

基于最新 `main`（含已合并的 `fix-pluggin-lock-deadlock`）的两个修复：

**1. 所有事件派发路径统一更新 `currentEv`**

`currentEv` 是 `jn.agent.get_current_chat_area` / `compact_memory` 的数据源。此前只有消息派发（`dispatchMessage`）和遗留 `OnWebhook` 会写入它，`onWebhook` / `onNotice` / `onRequest` / `onCronJob`（及遗留 `OnNotice` / `OnRequest`）不会——插件在这些回调里调用上述 API 时会读到**上一个消息事件**的陈旧数据，最坏可能对错误的 chat_area 执行 `compact_memory`。修复：所有派发入口在派发前 `currentEv.Store(event)`，保持语义一致。

**2. 内置命令执行不再依赖插件加载状态**

`execCommand` 对所有命令一律按 `pluginByName(node.PluginName)` 查插件——`/help` 注册在 `system` 名下，system 插件未加载时 `/help` 静默不可用。修复：`CommandOpts` / `CommandNode` 新增 `Builtin` 标记，`execCommand` 对内置命令（纯 Go 闭包、不触碰 LState）直接执行，插件命令路径（`pluginByName` + `stateMu` + `closed` 检查）保持不变。

## 影响范围

- [x] 后端（Go）
- [ ] 前端（web/）
- [ ] 文档
- [ ] 配置/部署
- [ ] 其他

## 验证

```bash
go build ./...                          # ✅
go vet ./... && gofmt -l internal/pluggin/  # ✅ 无告警
go test ./internal/pluggin/ -race -count=3  # ✅ 全部通过
```

测试：`TestOneBot11WriteAPIs` 断言补充 `err == nil`；新增 `TestBuiltinHelpNotRequireSystemPlugin` 回归（引擎未加载任何插件时 `/help` 仍可用，修复前必失败）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 内置 `/help` 命令无需加载 system 插件即可正常执行，并返回帮助内容。
* **问题修复**
  * 修复插件未加载时内置命令无法使用的问题。
  * 优化事件处理，确保插件回调能够获取最新的聊天上下文。
  * 修正 OneBot11 删除消息、禁言和踢人操作的成功状态判断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->