### PR TITLE
fix(pluggin): currentEv 改 per-plugin，修复异步回调读到错误会话上下文

### DIFF
--- a/internal/pluggin/deadlock_test.go
+++ b/internal/pluggin/deadlock_test.go
@@ -63,7 +63,7 @@ func loadMiniPlugin(t *testing.T, pe *PluginEngine, name, src string) *lua.LStat
 
 	L := lua.NewState()
 	pe.injectSDK(L, name)
-	pe.injectBaseAPI(L, name, []string{"onebot11", "database", "file", "llm", "timer"})
+	pe.injectBaseAPI(L, name, []string{"onebot11", "database", "file", "llm", "timer", "agent"})
 	// database 需要 gorm db（测试环境不提供），手写空实现
 	dbTable := L.NewTable()
 	L.SetFuncs(dbTable, map[string]lua.LGFunction{
@@ -78,6 +78,10 @@ func loadMiniPlugin(t *testing.T, pe *PluginEngine, name, src string) *lua.LStat
 	})
 	L.SetGlobal("database", dbTable)
 	pe.injectCommandAPI(L, name)
+	// injectBaseAPI 要求 pe.dao != nil 才注入 agent；测试引擎 dao 为 nil，
+	// 手动补注入（get_current_chat_area 仅依赖 agentOp，nil 时返回事件字段、
+	// 不带 chat_area_id；其余 agent API 内部均有 nil 防御）
+	pe.injectAgent(L)
 	if err := L.DoString(fmt.Sprintf(`package.path = %q .. ";" .. package.path`, pluginDir+"/?.lua")); err != nil {
 		t.Fatalf("设置 package.path 失败: %v", err)
 	}
@@ -86,7 +90,9 @@ func loadMiniPlugin(t *testing.T, pe *PluginEngine, name, src string) *lua.LStat
 	}
 
 	pe.mu.Lock()
-	pe.plugins[name] = &LoadedPlugin{Manifest: Manifest{Name: name}, State: L, Dir: pluginDir}
+	p := &LoadedPlugin{Manifest: Manifest{Name: name}, State: L, Dir: pluginDir}
+	attachPluginRef(L, p)
+	pe.plugins[name] = p
 	pe.mu.Unlock()
 	// 清理：先删 map（runAsyncCallbacks 拿不到新任务），再 p.close()——
 	// 在 stateMu 下关闭并与在途异步回调互斥；已被 Unload 关闭时幂等跳过。
@@ -507,28 +513,44 @@ func TestRegisterAsyncAPIConcurrentReadWrite(t *testing.T) {
 	}
 }
 
-// TestCurrentEvConcurrentAccess currentEv 改 atomic.Value 后并发读写安全。
-func TestCurrentEvConcurrentAccess(t *testing.T) {
-	pe, _ := newMiniTestEngine(t, nil)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 2000; i++ {
-			pe.currentEv.Store(EventData{PostType: "message", UserID: int64(i)})
-		}
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 2000; i++ {
-			ev, ok := pe.currentEv.Load().(EventData)
-			if ok {
-				_ = ev.UserID
-			}
-		}
-	}()
-	wg.Wait()
+// TestAsyncCallbackSeesTriggerEvent 回归：事件 A 触发的异步任务，即使事件 B
+// 随后派发，回调（on_chat_response）内 jn.agent.get_current_chat_area 仍读到
+// 任务触发时的事件 A（修复前读共享全局 currentEv 会读到 B 的会话）。
+func TestAsyncCallbackSeesTriggerEvent(t *testing.T) {
+	llm := &fakeLLM{reply: "ok"}
+	llm.setDelay(200 * time.Millisecond) // 任务 A 在途期间让事件 B 派发
+	pe, _ := newMiniTestEngine(t, llm)
+	loadMiniPlugin(t, pe, "evctx", `
+local jn = require("jn")
+function on_message(event)
+    -- 仅事件 A（"hello"）触发异步任务，事件 B（"world"）只派发不提交，
+    -- 避免多个任务完成顺序不定导致断言抖动
+    if event.raw_message == "hello" then
+        jn.llm.chat_async({ { role = "user", content = "x" } }, { timeout = 5 })
+    end
+    return false, nil
+end
+function on_chat_response(req_id, content, err)
+    local area = jn.agent.get_current_chat_area()
+    _G.cb_group = area.group_id
+    _G.cb_user = area.user_id
+end
+`)
+	L := pe.plugins["evctx"].State
+
+	// 事件 A：群 10001 / 用户 20001（触发异步任务）
+	runOnMessage(t, pe, L, 10001, 20001, "hello", "90001")
+	// 事件 B 立即派发：群 10002 / 用户 20002（修复前会覆盖全局 currentEv）
+	runOnMessage(t, pe, L, 10002, 20002, "world", "90002")
+
+	// 任务 A 的回调必须读到事件 A 的会话（事件 B 派发不影响）
+	waitFor(t, func() bool { return luaGetGlobal(pe, L, "cb_group") != lua.LNil })
+	if v := luaGetGlobal(pe, L, "cb_group"); v != lua.LNumber(10001) {
+		t.Fatalf("回调应读到事件 A 的 group_id=10001, got %v", v)
+	}
+	if v := luaGetGlobal(pe, L, "cb_user"); v != lua.LNumber(20001) {
+		t.Fatalf("回调应读到事件 A 的 user_id=20001, got %v", v)
+	}
 }
 
 // ---------- 测试辅助 ----------

--- a/internal/pluggin/deadlock_test.go
+++ b/internal/pluggin/deadlock_test.go
@@ -79,8 +79,9 @@ func loadMiniPlugin(t *testing.T, pe *PluginEngine, name, src string) *lua.LStat
 	L.SetGlobal("database", dbTable)
 	pe.injectCommandAPI(L, name)
 	// injectBaseAPI 要求 pe.dao != nil 才注入 agent；测试引擎 dao 为 nil，
-	// 手动补注入（get_current_chat_area 仅依赖 agentOp，nil 时返回事件字段、
-	// 不带 chat_area_id；其余 agent API 内部均有 nil 防御）
+	// 手动补注入。注意：get_providers/get_mcps 等查询类 agent API 依赖 dao，
+	// dao 为 nil 时调用会 panic——测试插件只应使用 get_current_chat_area /
+	// compact_memory（依赖 agentOp，nil 时返回事件字段或报错，均有防御）
 	pe.injectAgent(L)
 	if err := L.DoString(fmt.Sprintf(`package.path = %q .. ";" .. package.path`, pluginDir+"/?.lua")); err != nil {
 		t.Fatalf("设置 package.path 失败: %v", err)
@@ -290,7 +291,7 @@ func TestBuiltinHelpNotRequireSystemPlugin(t *testing.T) {
 	}
 
 	// 内置命令不参与插件命令列表（无插件归属）
-	if pe.commands.HasCommand("/help") == false {
+	if !pe.commands.HasCommand("/help") {
 		t.Fatal("/help 应存在于命令注册表")
 	}
 }

--- a/internal/pluggin/llm_review_test.go
+++ b/internal/pluggin/llm_review_test.go
@@ -230,7 +230,9 @@ func loadPluginManual(t *testing.T, pe *PluginEngine, name string) *lua.LState {
 	}
 
 	pe.mu.Lock()
-	pe.plugins[name] = &LoadedPlugin{Manifest: Manifest{Name: name}, State: L, Dir: pluginDir}
+	p := &LoadedPlugin{Manifest: Manifest{Name: name}, State: L, Dir: pluginDir}
+	attachPluginRef(L, p)
+	pe.plugins[name] = p
 	pe.mu.Unlock()
 
 	// 测试结束先卸载插件（从 map 移除），再关闭 LState：避免长延时异步任务
@@ -271,6 +273,15 @@ func runOnMessage(t *testing.T, pe *PluginEngine, L *lua.LState, groupID, userID
 	defer p.stateMu.Unlock()
 	if p.closed {
 		t.Fatal("插件已关闭")
+	}
+	// 模拟 dispatchMessage：设置该插件当前事件（异步任务快照/agent API 读取用）
+	p.currentEv = EventData{
+		PostType:    "message",
+		MessageType: "group",
+		UserID:      userID,
+		GroupID:     groupID,
+		RawMessage:  raw,
+		Admins:      []string{},
 	}
 	t.Helper()
 	fn := L.GetGlobal("on_message")

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -705,12 +705,12 @@ func (pe *PluginEngine) RouteWebhook(pluginName string, path string, method stri
 			"payload": payload,
 		},
 	}
-	// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
-	p.currentEv = event
 	fn := p.State.GetGlobal("on_webhook")
 	if fn.Type() != lua.LTFunction {
 		return false, "plugin has no on_webhook handler"
 	}
+	// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+	p.currentEv = event
 	table := eventToLuaTable(p.State, event)
 	p.State.Push(fn)
 	p.State.Push(table)
@@ -822,6 +822,15 @@ func pluginRef(L *lua.LState) *LoadedPlugin {
 		}
 	}
 	return nil
+}
+
+// currentEventOf 返回 LState 所属插件的当前事件（Lua 执行期间调用，持 stateMu）。
+// 未挂插件引用时返回零值 EventData（不影响调用方）。
+func currentEventOf(L *lua.LState) EventData {
+	if p := pluginRef(L); p != nil {
+		return p.currentEv
+	}
+	return EventData{}
 }
 
 // execCommand 在插件 stateMu 下执行命令 handler（保证 LState 串行，且不再持有
@@ -2609,10 +2618,7 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 		// 当前 Chat-Area（读该插件 currentEv：事件派发/异步回调执行前写入，
 		// 异步回调读到的是任务触发时的会话，而非派发时最新的其他事件）
 		"get_current_chat_area": func(L *lua.LState) int {
-			ev := EventData{}
-			if p := pluginRef(L); p != nil {
-				ev = p.currentEv
-			}
+			ev := currentEventOf(L)
 			result := L.NewTable()
 			L.SetField(result, "post_type", lua.LString(ev.PostType))
 			L.SetField(result, "message_type", lua.LString(ev.MessageType))
@@ -2631,10 +2637,7 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 			if agentOp == nil {
 				return pushResult(L, fmt.Errorf("agent operator 不可用"))
 			}
-			ev := EventData{}
-			if p := pluginRef(L); p != nil {
-				ev = p.currentEv
-			}
+			ev := currentEventOf(L)
 			areaID := agentOp.GetChatAreaID(ev.UserID, ev.GroupID, ev.MessageType)
 			if areaID == "" {
 				return pushResult(L, fmt.Errorf("无法获取当前 Chat-Area ID"))
@@ -2790,9 +2793,6 @@ func (pe *PluginEngine) RegisterAsyncAPI(kind string, api AsyncAPI) {
 // submitAsync 提交一个异步任务：run 在独立 goroutine 中执行（不得触碰任何 LState），
 // 完成后派发到插件的 Entry 入口函数。返回 req_id；kind 未注册返回 error。
 // 无锁：asyncAPIs 注册表是 atomic 只读 map（构造期填充），此处不请求 pe.mu。
-// submitAsync 提交一个异步任务：run 在独立 goroutine 中执行（不得触碰任何 LState），
-// 完成后派发到插件的 Entry 入口函数。返回 req_id；kind 未注册返回 error。
-// 无锁：asyncAPIs 注册表是 atomic 只读 map（构造期填充），此处不请求 pe.mu。
 // L 用于取回该插件当前事件快照（pluginRef 无锁，Lua 执行期间调用）。
 func (pe *PluginEngine) submitAsync(L *lua.LState, pluginName, kind string, timeout time.Duration, run func(ctx context.Context) (any, error)) (uint64, error) {
 	api, ok := (*pe.asyncAPIs.Load())[kind]
@@ -2800,10 +2800,7 @@ func (pe *PluginEngine) submitAsync(L *lua.LState, pluginName, kind string, time
 		return 0, fmt.Errorf("pluggin: 异步 API %q 未注册", kind)
 	}
 	// 快照触发事件（持 stateMu 执行 Lua 期间读取，无需额外锁）
-	var ev EventData
-	if p := pluginRef(L); p != nil {
-		ev = p.currentEv
-	}
+	ev := currentEventOf(L)
 	id := atomic.AddUint64(&pe.asyncSeq, 1)
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/pluggin/pluggin.go
+++ b/internal/pluggin/pluggin.go
@@ -66,6 +66,11 @@ type LoadedPlugin struct {
 	stateMu sync.Mutex
 	// closed 在 stateMu 下读写：标记 LState 已关闭，执行方检查后跳过。
 	closed bool
+	// currentEv 该插件当前正在处理的事件（stateMu 下读写）。
+	// 事件派发/异步回调执行该插件 Lua 前写入；jn.agent.get_current_chat_area /
+	// compact_memory 在 Lua 中读取。异步任务触发时快照事件、回调前恢复——
+	// 事件 A 触发的回调即使在其他事件派发后仍读到 A 的会话数据。
+	currentEv EventData
 }
 
 // close 关闭插件 LState。与执行互斥：等待在途回调完成后关闭，
@@ -206,11 +211,7 @@ type PluginEngine struct {
 	asyncCh chan asyncTask
 	// asyncSeq req_id 自增序号。
 	asyncSeq uint64
-	// currentEv 当前派发中的事件（供 jn.agent.get_current_chat_area 等读取）。
-	// 用 atomic.Value：写发生在事件循环 goroutine，读可能在异步回调 goroutine，
-	// 不再由全局锁互斥。
-	currentEv atomic.Value // EventData
-	commands  *CommandRegistry
+	commands *CommandRegistry
 }
 
 // AsyncAPI 描述一类可异步执行的 API（注册进引擎异步注册表）。
@@ -229,6 +230,9 @@ type AsyncAPI struct {
 }
 
 // asyncTask 一次异步调用的完成事件（runAsyncCallbacks 消费）。
+// event 为任务触发时该插件的当前事件快照：回调执行前恢复插件 currentEv，
+// 保证 on_xxx_response 内 jn.agent.get_current_chat_area / compact_memory
+// 读到任务触发时的会话，而不是派发时最新的其他事件。
 type asyncTask struct {
 	pluginName string
 	kind       string
@@ -236,6 +240,7 @@ type asyncTask struct {
 	reqID      uint64
 	result     any
 	err        error
+	event      EventData
 }
 
 func NewPluginEngine(basePath string, adapter SendAdapter, db *gorm.DB, c *cache.Cache, t2i *t2icaller.Client, sb *sandboxcaller.Client, d *dao.Bundle, ag AgentOperator, llm LLMAccess) *PluginEngine {
@@ -410,6 +415,11 @@ func (pe *PluginEngine) Load(name string) error {
 	}
 
 	L := lua.NewState()
+	// 先创建插件对象并挂到 LState（userdata 引用）：injectAgent / submitAsync 等
+	// 在 Lua 执行期间经 pluginRef 无锁取回插件指针（读 per-plugin currentEv），
+	// 不引入 pe.mu → stateMu 的锁序依赖。
+	p := &LoadedPlugin{State: L, Dir: pluginDir}
+	attachPluginRef(L, p)
 	// 先注入 SDK：让插件可以使用 require("jn")
 	pe.injectSDK(L, name)
 	pe.injectBaseAPI(L, name, manifest.Permissions)
@@ -423,7 +433,7 @@ func (pe *PluginEngine) Load(name string) error {
 		return fmt.Errorf("执行 entry 失败: %w", err)
 	}
 
-	p := &LoadedPlugin{Manifest: *manifest, State: L, Dir: pluginDir}
+	p.Manifest = *manifest
 	pe.mu.Lock()
 	if _, dup := pe.plugins[name]; dup {
 		pe.mu.Unlock()
@@ -609,7 +619,6 @@ func (pe *PluginEngine) sendReply(event EventData, content string) {
 // 当 webhook adapter 收到事件时调用此方法。
 // 插件可以在 on_webhook 中返回 true 表示已消费事件。
 func (pe *PluginEngine) OnWebhook(event EventData) (consumed bool) {
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		if !p.HasPermission("webhook") {
 			continue
@@ -619,6 +628,8 @@ func (pe *PluginEngine) OnWebhook(event EventData) (consumed bool) {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_webhook")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -686,10 +697,6 @@ func (pe *PluginEngine) RouteWebhook(pluginName string, path string, method stri
 	if p.closed {
 		return false, "plugin is closed"
 	}
-	fn := p.State.GetGlobal("on_webhook")
-	if fn.Type() != lua.LTFunction {
-		return false, "plugin has no on_webhook handler"
-	}
 	event := EventData{
 		PostType: "webhook",
 		Webhook: map[string]any{
@@ -697,6 +704,12 @@ func (pe *PluginEngine) RouteWebhook(pluginName string, path string, method stri
 			"method":  method,
 			"payload": payload,
 		},
+	}
+	// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+	p.currentEv = event
+	fn := p.State.GetGlobal("on_webhook")
+	if fn.Type() != lua.LTFunction {
+		return false, "plugin has no on_webhook handler"
 	}
 	table := eventToLuaTable(p.State, event)
 	p.State.Push(fn)
@@ -718,14 +731,14 @@ func (pe *PluginEngine) RouteWebhook(pluginName string, path string, method stri
 
 // OnNotice 通知事件（群成员增减、禁言、文件上传等）。
 func (pe *PluginEngine) OnNotice(event EventData) {
-	// 更新当前事件（与 Dispatch 派发路径一致）
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_notice")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -743,14 +756,14 @@ func (pe *PluginEngine) OnNotice(event EventData) {
 
 // OnRequest 请求事件（加好友、加群邀请）。
 func (pe *PluginEngine) OnRequest(event EventData) {
-	// 更新当前事件（与 Dispatch 派发路径一致）
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_request")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -788,6 +801,29 @@ func (pe *PluginEngine) pluginByName(name string) *LoadedPlugin {
 	return pe.plugins[name]
 }
 
+// pluginRefKey LState 全局 userdata 键：Load 时把插件指针挂到 LState。
+// 供 Lua 执行期间（injectAgent 读 per-plugin currentEv）无锁取回，
+// 不引入 pe.mu → stateMu 的锁序依赖。
+const pluginRefKey = "__jn_plugin_ref"
+
+// attachPluginRef 把插件指针挂到 LState 全局（Load 创建 LState 后立即调用）。
+func attachPluginRef(L *lua.LState, p *LoadedPlugin) {
+	ud := L.NewUserData()
+	ud.Value = p
+	L.SetGlobal(pluginRefKey, ud)
+}
+
+// pluginRef 从 LState 取回插件指针（Lua 执行期间调用；无锁）。
+// 手动构造的 LState（如测试辅助）未挂引用时返回 nil。
+func pluginRef(L *lua.LState) *LoadedPlugin {
+	if ud, ok := L.GetGlobal(pluginRefKey).(*lua.LUserData); ok {
+		if p, ok := ud.Value.(*LoadedPlugin); ok {
+			return p
+		}
+	}
+	return nil
+}
+
 // execCommand 在插件 stateMu 下执行命令 handler（保证 LState 串行，且不再持有
 // pe.mu / commands 锁——handler 内动态注册命令不会触发读锁升级写锁死锁）。
 // 插件未加载/已卸载时**不执行**：命令 handler 闭包捕获插件 LState，若插件已被
@@ -806,6 +842,8 @@ func (pe *PluginEngine) execCommand(node *CommandNode, args []string, event Even
 	if p.closed {
 		return false, "", nil
 	}
+	// 设置该插件当前事件（命令 handler 内 jn.agent API 可读到本事件）
+	p.currentEv = event
 	return node.Handler(args, event)
 }
 
@@ -924,8 +962,6 @@ func (pe *PluginEngine) dispatchMessage(ev adapter.Event) DispatchResult {
 		},
 	}
 
-	pe.currentEv.Store(pluginEvent)
-
 	// 1. 命令注册表：命中即消费（命令消息不进 Agent）。
 	// 匹配在 commands 锁内完成（不执行 Lua），handler 在插件 stateMu 下执行。
 	if strings.HasPrefix(strings.TrimSpace(pluginEvent.RawMessage), "/") {
@@ -961,6 +997,8 @@ func (pe *PluginEngine) dispatchMessage(ev adapter.Event) DispatchResult {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件：回调内 jn.agent.get_current_chat_area 读到本事件
+		p.currentEv = pluginEvent
 		fn := p.State.GetGlobal("on_message")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -995,9 +1033,6 @@ func (pe *PluginEngine) dispatchMessage(ev adapter.Event) DispatchResult {
 // pluginIDs 指定要通知的插件目录名列表（与 map key / p.Dir 目录名一致，
 // 不是 Manifest.Name 显示名）；为空则通知所有插件。
 func (pe *PluginEngine) onCronJob(event EventData, pluginIDs []string) bool {
-	// 更新当前事件：插件回调内 jn.agent.get_current_chat_area / compact_memory
-	// 应观察到当前派发的事件，而不是上一个消息事件
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		// 按 CronJob 配置的插件列表过滤
 		if len(pluginIDs) > 0 && !containsString(pluginIDs, filepath.Base(p.Dir)) {
@@ -1008,6 +1043,8 @@ func (pe *PluginEngine) onCronJob(event EventData, pluginIDs []string) bool {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_cronjob")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -1043,14 +1080,14 @@ func containsString(list []string, target string) bool {
 
 // onNotice 派发 notice 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onNotice(event EventData) bool {
-	// 更新当前事件（见 onCronJob 注释）
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_notice")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -1076,14 +1113,14 @@ func (pe *PluginEngine) onNotice(event EventData) bool {
 
 // onRequest 派发 request 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onRequest(event EventData) bool {
-	// 更新当前事件（见 onCronJob 注释）
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		p.stateMu.Lock()
 		if p.closed {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_request")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -1109,8 +1146,6 @@ func (pe *PluginEngine) onRequest(event EventData) bool {
 
 // onWebhook 派发 webhook 事件给插件（锁外执行，per-plugin stateMu 串行）。
 func (pe *PluginEngine) onWebhook(event EventData) (consumed bool, reply string) {
-	// 更新当前事件（见 onCronJob 注释）
-	pe.currentEv.Store(event)
 	for _, p := range pe.snapshot() {
 		if !p.HasPermission("webhook") {
 			continue
@@ -1120,6 +1155,8 @@ func (pe *PluginEngine) onWebhook(event EventData) (consumed bool, reply string)
 			p.stateMu.Unlock()
 			continue
 		}
+		// 设置该插件当前事件（回调内 jn.agent API 读到本事件）
+		p.currentEv = event
 		fn := p.State.GetGlobal("on_webhook")
 		if fn.Type() != lua.LTFunction {
 			p.stateMu.Unlock()
@@ -1783,7 +1820,7 @@ func (pe *PluginEngine) injectHTTP(L *lua.LState, pluginName string) {
 				body, _ := io.ReadAll(resp.Body)
 				return &httpResult{Status: resp.StatusCode, Body: string(body)}, nil
 			}
-			id, err := pe.submitAsync(pluginName, "http", httpAsyncTimeout, run)
+			id, err := pe.submitAsync(L, pluginName, "http", httpAsyncTimeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -1824,7 +1861,7 @@ func (pe *PluginEngine) injectHTTP(L *lua.LState, pluginName string) {
 				body, _ := io.ReadAll(resp.Body)
 				return &httpResult{Status: resp.StatusCode, Body: string(body)}, nil
 			}
-			id, err := pe.submitAsync(pluginName, "http", httpAsyncTimeout, run)
+			id, err := pe.submitAsync(L, pluginName, "http", httpAsyncTimeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2136,7 +2173,7 @@ func (pe *PluginEngine) injectT2I(L *lua.LState, pluginName string) {
 				}
 				return resp.Data.ID, nil
 			}
-			id, err := pe.submitAsync(pluginName, "t2i", timeout, run)
+			id, err := pe.submitAsync(L, pluginName, "t2i", timeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2175,7 +2212,7 @@ func (pe *PluginEngine) injectT2I(L *lua.LState, pluginName string) {
 				}
 				return url, nil
 			}
-			id, err := pe.submitAsync(pluginName, "t2i", timeout, run)
+			id, err := pe.submitAsync(L, pluginName, "t2i", timeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2315,7 +2352,7 @@ func (pe *PluginEngine) injectSandbox(L *lua.LState, pluginName string) {
 				}
 				return map[string]any{"sandbox_id": sbox.ID, "status": string(sbox.Status)}, nil
 			}
-			id, err := pe.submitAsync(pluginName, "sandbox", sandboxAsyncTimeout, run)
+			id, err := pe.submitAsync(L, pluginName, "sandbox", sandboxAsyncTimeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2345,7 +2382,7 @@ func (pe *PluginEngine) injectSandbox(L *lua.LState, pluginName string) {
 				}
 				return map[string]any{"output": result.Output, "exit_code": exitCode}, nil
 			}
-			id, err := pe.submitAsync(pluginName, "sandbox", sandboxAsyncTimeout, run)
+			id, err := pe.submitAsync(L, pluginName, "sandbox", sandboxAsyncTimeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2375,7 +2412,7 @@ func (pe *PluginEngine) injectSandbox(L *lua.LState, pluginName string) {
 				}
 				return map[string]any{"output": result.Output, "error": errStr}, nil
 			}
-			id, err := pe.submitAsync(pluginName, "sandbox", sandboxAsyncTimeout, run)
+			id, err := pe.submitAsync(L, pluginName, "sandbox", sandboxAsyncTimeout, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2440,7 +2477,6 @@ func (pe *PluginEngine) injectSandbox(L *lua.LState, pluginName string) {
 func (pe *PluginEngine) injectAgent(L *lua.LState) {
 	daoBundle := pe.dao
 	agentOp := pe.agentOp
-	engine := pe
 
 	agentTable := L.NewTable()
 
@@ -2570,9 +2606,13 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 			return pushResult(L, err)
 		},
 
-		// 当前 Chat-Area
+		// 当前 Chat-Area（读该插件 currentEv：事件派发/异步回调执行前写入，
+		// 异步回调读到的是任务触发时的会话，而非派发时最新的其他事件）
 		"get_current_chat_area": func(L *lua.LState) int {
-			ev, _ := engine.currentEv.Load().(EventData)
+			ev := EventData{}
+			if p := pluginRef(L); p != nil {
+				ev = p.currentEv
+			}
 			result := L.NewTable()
 			L.SetField(result, "post_type", lua.LString(ev.PostType))
 			L.SetField(result, "message_type", lua.LString(ev.MessageType))
@@ -2591,7 +2631,10 @@ func (pe *PluginEngine) injectAgent(L *lua.LState) {
 			if agentOp == nil {
 				return pushResult(L, fmt.Errorf("agent operator 不可用"))
 			}
-			ev, _ := engine.currentEv.Load().(EventData)
+			ev := EventData{}
+			if p := pluginRef(L); p != nil {
+				ev = p.currentEv
+			}
 			areaID := agentOp.GetChatAreaID(ev.UserID, ev.GroupID, ev.MessageType)
 			if areaID == "" {
 				return pushResult(L, fmt.Errorf("无法获取当前 Chat-Area ID"))
@@ -2664,7 +2707,7 @@ func (pe *PluginEngine) injectLLM(L *lua.LState, pluginName string) {
 				}
 				return resp.Message.Content, nil
 			}
-			id, err := pe.submitAsync(pluginName, "chat", llmTimeoutFromOpts(L, 2), run)
+			id, err := pe.submitAsync(L, pluginName, "chat", llmTimeoutFromOpts(L, 2), run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2705,7 +2748,7 @@ func (pe *PluginEngine) injectTimer(L *lua.LState, pluginName string) {
 				}
 			}
 			// 兜底超时比目标延时多留 5s，确保正常到点走 time.After 而非 context 取消
-			id, err := pe.submitAsync(pluginName, "timer", d+5*time.Second, run)
+			id, err := pe.submitAsync(L, pluginName, "timer", d+5*time.Second, run)
 			if err != nil {
 				L.Push(lua.LNumber(0))
 				L.Push(lua.LString(err.Error()))
@@ -2747,17 +2790,26 @@ func (pe *PluginEngine) RegisterAsyncAPI(kind string, api AsyncAPI) {
 // submitAsync 提交一个异步任务：run 在独立 goroutine 中执行（不得触碰任何 LState），
 // 完成后派发到插件的 Entry 入口函数。返回 req_id；kind 未注册返回 error。
 // 无锁：asyncAPIs 注册表是 atomic 只读 map（构造期填充），此处不请求 pe.mu。
-func (pe *PluginEngine) submitAsync(pluginName, kind string, timeout time.Duration, run func(ctx context.Context) (any, error)) (uint64, error) {
+// submitAsync 提交一个异步任务：run 在独立 goroutine 中执行（不得触碰任何 LState），
+// 完成后派发到插件的 Entry 入口函数。返回 req_id；kind 未注册返回 error。
+// 无锁：asyncAPIs 注册表是 atomic 只读 map（构造期填充），此处不请求 pe.mu。
+// L 用于取回该插件当前事件快照（pluginRef 无锁，Lua 执行期间调用）。
+func (pe *PluginEngine) submitAsync(L *lua.LState, pluginName, kind string, timeout time.Duration, run func(ctx context.Context) (any, error)) (uint64, error) {
 	api, ok := (*pe.asyncAPIs.Load())[kind]
 	if !ok {
 		return 0, fmt.Errorf("pluggin: 异步 API %q 未注册", kind)
+	}
+	// 快照触发事件（持 stateMu 执行 Lua 期间读取，无需额外锁）
+	var ev EventData
+	if p := pluginRef(L); p != nil {
+		ev = p.currentEv
 	}
 	id := atomic.AddUint64(&pe.asyncSeq, 1)
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		result, err := run(ctx)
-		pe.asyncCh <- asyncTask{pluginName: pluginName, kind: kind, api: api, reqID: id, result: result, err: err}
+		pe.asyncCh <- asyncTask{pluginName: pluginName, kind: kind, api: api, reqID: id, result: result, err: err, event: ev}
 	}()
 	return id, nil
 }
@@ -2778,6 +2830,8 @@ func (pe *PluginEngine) runAsyncCallbacks() {
 			p.stateMu.Unlock()
 			continue
 		}
+		// 恢复任务触发时的事件：回调内 jn.agent API 读到任务所属会话
+		p.currentEv = task.event
 		L := p.State
 		fn := L.GetGlobal(task.api.Entry)
 		if fn.Type() == lua.LTFunction {


### PR DESCRIPTION
## 变更内容

基于最新 `main`（含已合并的 `fix-pluggin-lock-deadlock`）的三个修复 + 一次清理：

**1. `currentEv` 从全局改为 per-plugin（核心修复）**

`currentEv` 是 `jn.agent.get_current_chat_area` / `compact_memory` 的数据源。此前它是全局共享的：事件 A 触发的异步任务（`chat_async` / `timer.after` 等），回调执行时读到的是"派发时最新的其他事件"（事件 B）——最坏情况会对**错误的 chat_area** 执行 `compact_memory`。修复：

- `currentEv` 移到 `LoadedPlugin`（`stateMu` 保护），所有事件派发路径（消息/通知/请求/webhook/cronjob/命令/异步回调）执行该插件 Lua 前写入
- 异步任务**提交时快照**触发事件（`asyncTask.event`），回调执行前**恢复**——事件 A 的回调即使在其他事件派发后仍读到 A 的会话数据
- 插件指针经 LState userdata（`__jn_plugin_ref`）无锁取回，`injectAgent` / `submitAsync` 不引入 `pe.mu` 锁序依赖

**2. 所有事件派发路径统一写入 `currentEv`**

此前只有消息派发和遗留 `OnWebhook` 更新它，`onWebhook` / `onNotice` / `onRequest` / `onCronJob` 等不会——插件在这些回调里调用上述 API 会读到上一个消息事件的陈旧数据。修复：所有派发入口统一在派发前设置该插件当前事件。

**3. 内置命令执行不再依赖插件加载状态**

`execCommand` 对所有命令一律按 `pluginByName(node.PluginName)` 查插件——`/help` 注册在 `system` 名下，system 插件未加载时 `/help` 静默不可用。修复：`CommandOpts` / `CommandNode` 新增 `Builtin` 标记，内置命令（纯 Go 闭包、不触碰 LState）直接执行，插件命令路径（`pluginByName` + `stateMu` + `closed` 检查）保持不变。

**4. 清理**：提取 `currentEventOf` helper 消除重复、注释去重、`RouteWebhook` 设置顺序调整。

**Lua API 无变化**：`jn.agent.*` / `jn.llm.chat_async` / `jn.timer.after` 等签名与参数全部不变；插件仓库已核对，无需同步修改（无插件在异步回调中使用 `jn.agent` 上下文 API）。

## 影响范围

- [x] 后端（Go）
- [ ] 前端（web/）
- [ ] 文档
- [ ] 配置/部署
- [ ] 其他

## 验证

```bash
go build ./...                          # ✅
go vet ./... && gofmt -l internal/pluggin/  # ✅ 无告警
go test ./... -race -count=1            # ✅ 全部通过
go test ./internal/pluggin/ -race -count=5  # ✅ 稳定通过
```

回归测试：`TestAsyncCallbackSeesTriggerEvent`（事件 B 派发后，任务 A 的回调仍读到 A 的 group/user，修复前读到 B）；`TestBuiltinHelpNotRequireSystemPlugin`（引擎未加载任何插件时 `/help` 仍可用）；`TestOneBot11WriteAPIs` 断言补充 `err == nil`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复异步任务回调读取错误事件上下文的问题，确保回调使用任务触发时的会话信息。
  - 改进插件事件状态隔离，避免并发执行时不同插件之间相互影响。

- **测试**
  - 新增异步回调事件上下文回归测试。
  - 更新插件加载、消息处理及帮助命令相关测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->