### PR TITLE
fix(agent): resolve group image recognition failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/fatih/color v1.19.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/mark3labs/mcp-go v0.56.0
 	github.com/openai/openai-go/v3 v3.43.0
 	github.com/redis/go-redis/v9 v9.21.0
@@ -42,7 +43,6 @@ require (
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -217,7 +217,7 @@ func (h *HagoCenter) Init(ctx context.Context, cfg Config) error {
 	tool.RegisterBuiltinTools(h.Tools, cfg.Adapter,
 		func() *sandboxcaller.Client { return h.SandboxClient },
 		func() *t2icaller.Client { return h.T2IClient },
-		h.Providers.SelectModel(provider.ModelTypeImage),
+		func() provider.Provider { return h.Providers.SelectModel(provider.ModelTypeImage) },
 		func(ctx context.Context) string {
 			if sc := GetMsgSessionCtx(ctx); sc != nil {
 				return sc.SessionCtxStr

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -26,9 +26,11 @@ const SilenceToken = "__NO_REPLY__"
 // cqImageCodeRe 匹配 CQ 图片码段（如 [CQ:image,file=...,url=...]）。
 var cqImageCodeRe = regexp.MustCompile(`\[CQ:image[^\]]*\]`)
 
-// qqCDNURLRe 匹配 QQ 图床 URL 文本（到空白/逗号/右括号为止），
-// 用于将 &amp; 解码范围限制在 URL 内，不影响消息中的其他文本。
-var qqCDNURLRe = regexp.MustCompile(`https?://[^\s,\]]*multimedia\.nt\.qq\.com\.cn[^\s,\]]*`)
+// qqCDNURLRe 匹配 QQ 图床 URL 文本（scheme 后必须是 multimedia.nt.qq.com.cn 主机，
+// 到空白/逗号/右括号为止），用于将 &amp; 解码范围限制在 URL 内。
+// 主机名紧跟在 scheme 后：https://example.com/.../multimedia.nt.qq.com.cn 这类
+// 路径中携带该字符串的 URL 不会误匹配。
+var qqCDNURLRe = regexp.MustCompile(`https?://multimedia\.nt\.qq\.com\.cn[^\s,\]]*`)
 
 // decodeQQImageEntities 仅解码图片 URL 相关文本中的 HTML 实体（&amp; → &）：
 //   - CQ 图片码内部的实体（QQ 图床 URL 的查询参数以 &amp; 分隔，原样发给 LLM 会被复刻成无法下载的 URL）

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -23,6 +23,26 @@ import (
 // prompt 会告知 LLM："判定不回复时输出 __NO_REPLY__，系统检测到后自动丢弃"。
 const SilenceToken = "__NO_REPLY__"
 
+// cqImageCodeRe 匹配 CQ 图片码段（如 [CQ:image,file=...,url=...]）。
+var cqImageCodeRe = regexp.MustCompile(`\[CQ:image[^\]]*\]`)
+
+// decodeQQImageEntities 仅解码图片 URL 相关文本中的 HTML 实体（&amp; → &）：
+//   - CQ 图片码内部的实体（QQ 图床 URL 的查询参数以 &amp; 分隔，原样发给 LLM 会被复刻成无法下载的 URL）
+//   - 纯文本形式（非 CQ 码）的 QQ 图床 URL 整体解码
+//
+// 普通用户文本（如字面 "&amp;"）保持不变，避免 LLM 收到的内容与原始消息不一致。
+func decodeQQImageEntities(s string) string {
+	if strings.Contains(s, "[CQ:image") {
+		s = cqImageCodeRe.ReplaceAllStringFunc(s, func(m string) string {
+			return strings.ReplaceAll(m, "&amp;", "&")
+		})
+	}
+	if strings.Contains(s, "multimedia.nt.qq.com.cn") {
+		s = strings.ReplaceAll(s, "&amp;", "&")
+	}
+	return s
+}
+
 // ReplySettings 包含从回复策略配置中提取的 per-message 设置。
 // 通过函数参数传递（而非 HagoCenter 共享字段），避免数据竞争。
 type ReplySettings struct {
@@ -843,9 +863,9 @@ func (h *HagoCenter) handleMessage(ctx context.Context, events []adapter.Event, 
 	// 主消息（本组最后一条）是当前需要回复的消息。避免模型把多人的问题
 	// 拼在一起一次回复（回复串味），也避免并行组重复消费同一消息。
 	for i, mu := range userMsgs {
-		// QQ 消息文本带 HTML 实体（&amp; 等），LLM 原样复刻易得到无法下载的 URL；
-		// 发给模型前解码为字面字符（存储记录仍保留原文）
-		mu = strings.ReplaceAll(mu, "&amp;", "&")
+		// QQ 图片 URL 在 CQ 码里带 HTML 实体（&amp;），LLM 原样复刻易得到无法下载的 URL；
+		// 仅解码 CQ 图片码/QQ 图床 URL 中的实体，普通用户文本（如字面 &amp;）原样保留
+		mu = decodeQQImageEntities(mu)
 		content := mu
 		if i != mainIdx {
 			content = "【背景消息·来自其他用户，无需逐一回复】" + mu

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -26,11 +26,11 @@ const SilenceToken = "__NO_REPLY__"
 // cqImageCodeRe 匹配 CQ 图片码段（如 [CQ:image,file=...,url=...]）。
 var cqImageCodeRe = regexp.MustCompile(`\[CQ:image[^\]]*\]`)
 
-// qqCDNURLRe 匹配 QQ 图床 URL 文本（scheme 后必须是 multimedia.nt.qq.com.cn 主机，
-// 到空白/逗号/右括号为止），用于将 &amp; 解码范围限制在 URL 内。
-// 主机名紧跟在 scheme 后：https://example.com/.../multimedia.nt.qq.com.cn 这类
-// 路径中携带该字符串的 URL 不会误匹配。
-var qqCDNURLRe = regexp.MustCompile(`https?://multimedia\.nt\.qq\.com\.cn[^\s,\]]*`)
+// qqCDNURLRe 匹配 QQ 图床 URL 文本（scheme 后必须是 multimedia.nt.qq.com.cn 主机）。
+// 主机名后只允许：合法端口、路径/查询/片段、URL 分隔符（空白/逗号/]）或字符串结尾；
+// 拒绝 multimedia.nt.qq.com.cn.evil 与 ...@evil.com 这类实际主机不同的 URL。
+// Go regexp 为 RE2（无 lookahead），用分支表达边界。
+var qqCDNURLRe = regexp.MustCompile(`https?://multimedia\.nt\.qq\.com\.cn(:\d+)?(?:[/?#][^\s,\]]*|[\s,\]]|$)`)
 
 // decodeQQImageEntities 仅解码图片 URL 相关文本中的 HTML 实体（&amp; → &）：
 //   - CQ 图片码内部的实体（QQ 图床 URL 的查询参数以 &amp; 分隔，原样发给 LLM 会被复刻成无法下载的 URL）

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -26,9 +26,13 @@ const SilenceToken = "__NO_REPLY__"
 // cqImageCodeRe 匹配 CQ 图片码段（如 [CQ:image,file=...,url=...]）。
 var cqImageCodeRe = regexp.MustCompile(`\[CQ:image[^\]]*\]`)
 
+// qqCDNURLRe 匹配 QQ 图床 URL 文本（到空白/逗号/右括号为止），
+// 用于将 &amp; 解码范围限制在 URL 内，不影响消息中的其他文本。
+var qqCDNURLRe = regexp.MustCompile(`https?://[^\s,\]]*multimedia\.nt\.qq\.com\.cn[^\s,\]]*`)
+
 // decodeQQImageEntities 仅解码图片 URL 相关文本中的 HTML 实体（&amp; → &）：
 //   - CQ 图片码内部的实体（QQ 图床 URL 的查询参数以 &amp; 分隔，原样发给 LLM 会被复刻成无法下载的 URL）
-//   - 纯文本形式（非 CQ 码）的 QQ 图床 URL 整体解码
+//   - 纯文本 QQ 图床 URL 自身的实体（按 URL 匹配范围，不波及相邻文本）
 //
 // 普通用户文本（如字面 "&amp;"）保持不变，避免 LLM 收到的内容与原始消息不一致。
 func decodeQQImageEntities(s string) string {
@@ -38,7 +42,9 @@ func decodeQQImageEntities(s string) string {
 		})
 	}
 	if strings.Contains(s, "multimedia.nt.qq.com.cn") {
-		s = strings.ReplaceAll(s, "&amp;", "&")
+		s = qqCDNURLRe.ReplaceAllStringFunc(s, func(m string) string {
+			return strings.ReplaceAll(m, "&amp;", "&")
+		})
 	}
 	return s
 }

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -140,8 +140,8 @@ func (h *HagoCenter) checkReplyStrategyFast(ctx context.Context, ev adapter.Even
 		log.Debug("回复策略: 完全不回复", "group_id", msg.GroupID, "user_id", msg.UserID)
 		return false
 	case models.StrategyAtOnly:
-		if msg.MessageType == "group" && !h.isAtSelf(msg.RawMessage) {
-			log.Debug("回复策略: 仅@我时回复，跳过", "group_id", msg.GroupID, "user_id", msg.UserID)
+		if msg.MessageType == "group" && !h.isAtSelf(msg.RawMessage, ev.SelfID) {
+			log.Info("回复策略: 仅@我时回复，跳过", "group_id", msg.GroupID, "user_id", msg.UserID, "self_id", ev.SelfID)
 			return false
 		}
 		return true
@@ -599,7 +599,7 @@ func (h *HagoCenter) filterRelevant(ctx context.Context, events []adapter.Event,
 			continue
 		}
 		// L1 规则快路径：@ 自己 / 插件命令 / 提及名字 → 必回，无需 LLM
-		if h.isAtSelf(msg.RawMessage) || h.isPluginCommand(msg.RawMessage) || isDefinitelyRelevant(msg, rs) {
+		if h.isAtSelf(msg.RawMessage, ev.SelfID) || h.isPluginCommand(msg.RawMessage) || isDefinitelyRelevant(msg, rs) {
 			mustKeep = append(mustKeep, ev)
 			continue
 		}
@@ -843,6 +843,9 @@ func (h *HagoCenter) handleMessage(ctx context.Context, events []adapter.Event, 
 	// 主消息（本组最后一条）是当前需要回复的消息。避免模型把多人的问题
 	// 拼在一起一次回复（回复串味），也避免并行组重复消费同一消息。
 	for i, mu := range userMsgs {
+		// QQ 消息文本带 HTML 实体（&amp; 等），LLM 原样复刻易得到无法下载的 URL；
+		// 发给模型前解码为字面字符（存储记录仍保留原文）
+		mu = strings.ReplaceAll(mu, "&amp;", "&")
 		content := mu
 		if i != mainIdx {
 			content = "【背景消息·来自其他用户，无需逐一回复】" + mu

--- a/internal/agent/event_decode_test.go
+++ b/internal/agent/event_decode_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import "testing"
+
+// TestDecodeQQImageEntitiesCQImageCode CQ 图片码内的 &amp; 必须解码为 &（QQ 图床 URL 查询参数），
+// 否则 LLM 复刻 URL 时得到无法下载的地址（400 invalid rkey 根因之一）。
+func TestDecodeQQImageEntitiesCQImageCode(t *testing.T) {
+	in := `[CQ:image,file=abc.png,url=https://multimedia.nt.qq.com.cn/download?appid=1407&amp;fileid=xyz&amp;rkey=CAESM]
+`
+	want := `[CQ:image,file=abc.png,url=https://multimedia.nt.qq.com.cn/download?appid=1407&fileid=xyz&rkey=CAESM]
+`
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("CQ 图片码解码错误\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestDecodeQQImageEntitiesKeepsLiteralAmp 普通用户文本中的字面 &amp; 必须原样保留，
+// 防止 LLM 收到的内容与原始消息不一致（CodeRabbit 审查点）。
+func TestDecodeQQImageEntitiesKeepsLiteralAmp(t *testing.T) {
+	in := "今天的折扣码是 A&amp;B，记得查收"
+	want := in
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("普通文本被改写\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestDecodeQQImageEntitiesPlainCDNURL 纯文本（非 CQ 码）形式的 QQ 图床 URL 也要解码。
+func TestDecodeQQImageEntitiesPlainCDNURL(t *testing.T) {
+	in := `看图 https://multimedia.nt.qq.com.cn/download?appid=1407&amp;rkey=x`
+	want := `看图 https://multimedia.nt.qq.com.cn/download?appid=1407&rkey=x`
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("纯文本 CDN URL 解码错误\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestDecodeQQImageEntitiesMixed 图片码 + 普通文本混合：只解码图片相关部分。
+func TestDecodeQQImageEntitiesMixed(t *testing.T) {
+	in := `图片来了 [CQ:image,url=http://a.cn/x?p=1&amp;q=2] 请把 A&amp;B 发我`
+	want := `图片来了 [CQ:image,url=http://a.cn/x?p=1&q=2] 请把 A&amp;B 发我`
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("混合消息解码错误\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/internal/agent/event_decode_test.go
+++ b/internal/agent/event_decode_test.go
@@ -53,6 +53,40 @@ func TestDecodeQQImageEntitiesForeignHostWithCDNInPath(t *testing.T) {
 	}
 }
 
+// TestDecodeQQImageEntitiesEvilHostSuffix 回归：主机名带 .evil 后缀时实际主机不同，
+// 不得解码（CodeRabbit 审查点）。
+func TestDecodeQQImageEntitiesEvilHostSuffix(t *testing.T) {
+	in := `https://multimedia.nt.qq.com.cn.evil/download?a=1&amp;b=2`
+	want := in
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf(".evil 后缀 URL 误解码\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestDecodeQQImageEntitiesUserinfoAttack 回归：@evil.com 形式的 userinfo 注入
+// 实际主机是 evil.com，不得解码（CodeRabbit 审查点）。
+func TestDecodeQQImageEntitiesUserinfoAttack(t *testing.T) {
+	in := `https://multimedia.nt.qq.com.cn@evil.com/download?a=1&amp;b=2`
+	want := in
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("@userinfo 注入 URL 误解码\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestDecodeQQImageEntitiesPortAndEnd 合法形态保持匹配：带端口、或主机后直接结束的 URL。
+func TestDecodeQQImageEntitiesPortAndEnd(t *testing.T) {
+	in := `https://multimedia.nt.qq.com.cn:443/download?a=1&amp;b=2 结束`
+	want := `https://multimedia.nt.qq.com.cn:443/download?a=1&b=2 结束`
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("带端口 URL 解码错误\n got: %q\nwant: %q", got, want)
+	}
+	// 主机后无路径/参数：正则应匹配（无实体可解码，结果不变即正确）
+	plain := "https://multimedia.nt.qq.com.cn"
+	if got := decodeQQImageEntities(plain); got != plain {
+		t.Fatalf("裸主机 URL 处理错误\n got: %q\nwant: %q", got, plain)
+	}
+}
+
 // TestDecodeQQImageEntitiesMixed 图片码 + 普通文本混合：只解码图片相关部分。
 func TestDecodeQQImageEntitiesMixed(t *testing.T) {
 	in := `图片来了 [CQ:image,url=http://a.cn/x?p=1&amp;q=2] 请把 A&amp;B 发我`

--- a/internal/agent/event_decode_test.go
+++ b/internal/agent/event_decode_test.go
@@ -33,6 +33,16 @@ func TestDecodeQQImageEntitiesPlainCDNURL(t *testing.T) {
 	}
 }
 
+// TestDecodeQQImageEntitiesCDNPlusLiteralAmp 回归：CDN URL 与独立字面 &amp; 共存时，
+// 只解码 URL 范围内的实体，普通文本原样保留（CodeRabbit 最新审查点）。
+func TestDecodeQQImageEntitiesCDNPlusLiteralAmp(t *testing.T) {
+	in := `看图 https://multimedia.nt.qq.com.cn/download?appid=1407&amp;rkey=x 代码 A&amp;B`
+	want := `看图 https://multimedia.nt.qq.com.cn/download?appid=1407&rkey=x 代码 A&amp;B`
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("URL 范围解码错误\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestDecodeQQImageEntitiesMixed 图片码 + 普通文本混合：只解码图片相关部分。
 func TestDecodeQQImageEntitiesMixed(t *testing.T) {
 	in := `图片来了 [CQ:image,url=http://a.cn/x?p=1&amp;q=2] 请把 A&amp;B 发我`

--- a/internal/agent/event_decode_test.go
+++ b/internal/agent/event_decode_test.go
@@ -43,6 +43,16 @@ func TestDecodeQQImageEntitiesCDNPlusLiteralAmp(t *testing.T) {
 	}
 }
 
+// TestDecodeQQImageEntitiesForeignHostWithCDNInPath 回归：其他主机的路径里
+// 包含 multimedia.nt.qq.com.cn 字符串时不得解码（非 QQ CDN URL，CodeRabbit 审查点）。
+func TestDecodeQQImageEntitiesForeignHostWithCDNInPath(t *testing.T) {
+	in := `https://example.com/path/multimedia.nt.qq.com.cn/download?a=1&amp;b=2`
+	want := in
+	if got := decodeQQImageEntities(in); got != want {
+		t.Fatalf("非 CDN 主机误解码\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestDecodeQQImageEntitiesMixed 图片码 + 普通文本混合：只解码图片相关部分。
 func TestDecodeQQImageEntitiesMixed(t *testing.T) {
 	in := `图片来了 [CQ:image,url=http://a.cn/x?p=1&amp;q=2] 请把 A&amp;B 发我`

--- a/internal/agent/reply_strategy.go
+++ b/internal/agent/reply_strategy.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +11,7 @@ import (
 
 	"JuanNiang-Neo/internal/adapter"
 	"JuanNiang-Neo/internal/agent/provider"
+	"JuanNiang-Neo/internal/agent/tool"
 	"JuanNiang-Neo/internal/core/models"
 )
 
@@ -308,7 +307,7 @@ func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.Me
 
 请以 JSON 格式回复: {"relevance": 0.0-1.0, "reason": "简短原因"}`, h.SelfNickname, selfQQ, msg.Sender.Nickname, msg.UserID, h.SelfNickname)
 					// 下载图片字节并调用 Vision（此前误传 nil，模型实际看不到图片）
-					imgBytes, err := h.fetchImageBytes(ctx, url, seg)
+					imgBytes, err := h.fetchImageBytes(judgeCtx, url, seg)
 					if err != nil {
 						log.Warn("下载图片失败", "url", url, "err", err)
 						return judgeFailVerdict(rs, "图片下载失败")
@@ -457,12 +456,10 @@ func extractImageURL(seg adapter.Segment) string {
 }
 
 // fetchImageBytes 下载图片消息的字节内容，供 Vision 模型识图。
-// http(s) URL 直接下载；file 路径（QQ 本地路径）经 onebot11 get_image 转为可下载 URL。
-// 携带浏览器 UA：QQ 图片服务器会校验 User-Agent，缺失 UA 可能返回 403。
+// http(s) URL 直接下载（复用 tool.DownloadImageBytes：候选解码变体 + 大小上限）；
+// file 路径（QQ 本地路径）先经 onebot11 get_image 转为可下载 URL。
 func (h *HagoCenter) fetchImageBytes(ctx context.Context, rawURL string, seg adapter.Segment) ([]byte, error) {
-	urlStr := rawURL
-	// QQ 图床 URL 带 HTML 实体 &amp;，先解码为 & 再使用
-	urlStr = strings.ReplaceAll(urlStr, "&amp;", "&")
+	urlStr := strings.TrimSpace(rawURL)
 	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
 		if h.Adapter == nil {
 			return nil, fmt.Errorf("adapter 未就绪，无法解析图片路径")
@@ -476,26 +473,7 @@ func (h *HagoCenter) fetchImageBytes(ctx context.Context, rawURL string, seg ada
 			urlStr = info.File
 		}
 	}
-	// file 分支经 get_image 返回的 URL 也可能带 HTML 实体，统一再解码一次
-	urlStr = strings.ReplaceAll(urlStr, "&amp;", "&")
-	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
-		return nil, fmt.Errorf("无法解析图片 URL: %q", urlStr)
-	}
-	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; JuanNiang-Neo)")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("图片下载 HTTP %d", resp.StatusCode)
-	}
-	return io.ReadAll(resp.Body)
+	return tool.DownloadImageBytes(ctx, urlStr)
 }
 
 // getRecentMessages 获取 ChatArea 中最近 N 条消息（不含当前消息）。

--- a/internal/agent/reply_strategy.go
+++ b/internal/agent/reply_strategy.go
@@ -461,7 +461,9 @@ func extractImageURL(seg adapter.Segment) string {
 // 携带浏览器 UA：QQ 图片服务器会校验 User-Agent，缺失 UA 可能返回 403。
 func (h *HagoCenter) fetchImageBytes(ctx context.Context, rawURL string, seg adapter.Segment) ([]byte, error) {
 	urlStr := rawURL
-	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+	// QQ 图床 URL 带 HTML 实体 &amp;，先解码为 & 再使用
+	urlStr = strings.ReplaceAll(urlStr, "&amp;", "&")
+	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
 		if h.Adapter == nil {
 			return nil, fmt.Errorf("adapter 未就绪，无法解析图片路径")
 		}
@@ -474,6 +476,8 @@ func (h *HagoCenter) fetchImageBytes(ctx context.Context, rawURL string, seg ada
 			urlStr = info.File
 		}
 	}
+	// file 分支经 get_image 返回的 URL 也可能带 HTML 实体，统一再解码一次
+	urlStr = strings.ReplaceAll(urlStr, "&amp;", "&")
 	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
 		return nil, fmt.Errorf("无法解析图片 URL: %q", urlStr)
 	}
@@ -534,11 +538,14 @@ func (h *HagoCenter) getRecentMessagesByMsgType(ctx context.Context, msgType str
 }
 
 // isAtSelf 检查消息是否 @ 了机器人自己。
-// 优先使用 Adapter 实时 SelfID（防止 Init 时 QQ bot 尚未连接导致缓存为 0），
-// 回退到启动时缓存的 SelfQQ。
-func (h *HagoCenter) isAtSelf(rawMsg string) bool {
+// SelfID 优先级：事件自带的 self_id（多连接时确定性归属，不依赖 map 遍历顺序）
+// > Adapter 实时 SelfID > 启动时缓存的 SelfQQ。
+func (h *HagoCenter) isAtSelf(rawMsg string, eventSelfID int64) bool {
 	selfQQ := h.SelfQQ
-	if h.Adapter != nil {
+	if eventSelfID != 0 {
+		selfQQ = eventSelfID
+	}
+	if selfQQ == 0 && h.Adapter != nil {
 		if id := h.Adapter.SelfID(); id != 0 {
 			selfQQ = id
 		}

--- a/internal/agent/reply_strategy.go
+++ b/internal/agent/reply_strategy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -305,8 +307,13 @@ func (h *HagoCenter) relevanceAgentEvaluate(ctx context.Context, msg *adapter.Me
 - 如果图片是纯表情包、风景照、美食照等与任务无关的内容，相关度应该低
 
 请以 JSON 格式回复: {"relevance": 0.0-1.0, "reason": "简短原因"}`, h.SelfNickname, selfQQ, msg.Sender.Nickname, msg.UserID, h.SelfNickname)
-					// 下载图片并调用 Vision
-					resp, err := visionModel.Vision(judgeCtx, nil, prompt) // Vision expects raw image bytes
+					// 下载图片字节并调用 Vision（此前误传 nil，模型实际看不到图片）
+					imgBytes, err := h.fetchImageBytes(ctx, url, seg)
+					if err != nil {
+						log.Warn("下载图片失败", "url", url, "err", err)
+						return judgeFailVerdict(rs, "图片下载失败")
+					}
+					resp, err := visionModel.Vision(judgeCtx, imgBytes, prompt) // Vision expects raw image bytes
 					if err != nil {
 						log.Warn("Vision 调用失败", "err", err)
 						return judgeFailVerdict(rs, "Vision 调用失败")
@@ -447,6 +454,44 @@ func extractImageURL(seg adapter.Segment) string {
 		}
 	}
 	return ""
+}
+
+// fetchImageBytes 下载图片消息的字节内容，供 Vision 模型识图。
+// http(s) URL 直接下载；file 路径（QQ 本地路径）经 onebot11 get_image 转为可下载 URL。
+// 携带浏览器 UA：QQ 图片服务器会校验 User-Agent，缺失 UA 可能返回 403。
+func (h *HagoCenter) fetchImageBytes(ctx context.Context, rawURL string, seg adapter.Segment) ([]byte, error) {
+	urlStr := rawURL
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		if h.Adapter == nil {
+			return nil, fmt.Errorf("adapter 未就绪，无法解析图片路径")
+		}
+		info, err := h.Adapter.GetImage(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("get_image 失败: %w", err)
+		}
+		urlStr = info.URL
+		if urlStr == "" {
+			urlStr = info.File
+		}
+	}
+	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
+		return nil, fmt.Errorf("无法解析图片 URL: %q", urlStr)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; JuanNiang-Neo)")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("图片下载 HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
 }
 
 // getRecentMessages 获取 ChatArea 中最近 N 条消息（不含当前消息）。

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -1154,11 +1154,13 @@ func blockedIP(ip net.IP) bool {
 	return cgnatBlock.Contains(ip)
 }
 
-// dialRestricted 是受限 DialContext：请求前解析目标 host 的实际 IP 并拒绝非公网地址。
-// http.Transport 对每次连接（含重定向目标、DNS 解析后的 IP）都会经过这里，
-// 因此公开 URL 重定向到内部地址同样会被拦截。
+// dialRestricted 是受限 DialContext：请求前解析目标 host 的实际 IP，
+// 拒绝非公网地址后，**直接连接该 IP**（而非让 net.Dialer 再次解析域名）。
+// 这保证"校验的 IP"与"实际连接的 IP"是同一个，防止 DNS rebinding 绕过；
+// http.Transport 的 TLS SNI / Host 头仍取自 URL 主机名，不受影响。
+// 对每次连接（含重定向目标）都会经过这里，公开 URL 重定向到内部地址同样被拦截。
 func dialRestricted(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, _, err := net.SplitHostPort(addr)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -1166,12 +1168,26 @@ func dialRestricted(ctx context.Context, network, addr string) (net.Conn, error)
 	if err != nil {
 		return nil, err
 	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("无法解析主机: %s", host)
+	}
+	// 任一解析结果命中拒绝段即整体拒绝
 	for _, ip := range ips {
 		if blockedIP(ip.IP) {
 			return nil, fmt.Errorf("拒绝访问非公网地址: %s (%s)", host, ip.IP)
 		}
 	}
-	return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, addr)
+	// 依次尝试连接每个已校验通过的 IP（解析结果与连接目标一致）
+	var lastErr error
+	for _, ip := range ips {
+		dialAddr := net.JoinHostPort(ip.IP.String(), port)
+		conn, err := (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, dialAddr)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 // newImageDownloadClient 构造受限 HTTP 客户端：禁用代理（防止代理绕过 SSRF 检查），

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -1130,6 +1131,61 @@ func vision(getImageModel func() provider.Provider) *onebotTool {
 // MaxImageBytes 图片下载的最大字节数，防止超大响应耗尽内存（OOM）。
 const MaxImageBytes = 25 << 20 // 25MB
 
+// ---------- SSRF 防护 ----------
+
+// cgnatBlock 是 CGNAT 共享地址段（100.64.0.0/10，RFC 6598），不对外路由。
+var cgnatBlock = mustCIDR("100.64.0.0/10")
+
+func mustCIDR(s string) *net.IPNet {
+	_, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipNet
+}
+
+// blockedIP 判断 IP 是否为 SSRF 防护应拒绝的地址：
+// loopback、私网（RFC1918 / fc00::/7）、链路本地、组播、未指定及 CGNAT 段。
+func blockedIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	return cgnatBlock.Contains(ip)
+}
+
+// dialRestricted 是受限 DialContext：请求前解析目标 host 的实际 IP 并拒绝非公网地址。
+// http.Transport 对每次连接（含重定向目标、DNS 解析后的 IP）都会经过这里，
+// 因此公开 URL 重定向到内部地址同样会被拦截。
+func dialRestricted(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, ip := range ips {
+		if blockedIP(ip.IP) {
+			return nil, fmt.Errorf("拒绝访问非公网地址: %s (%s)", host, ip.IP)
+		}
+	}
+	return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, addr)
+}
+
+// newImageDownloadClient 构造受限 HTTP 客户端：禁用代理（防止代理绕过 SSRF 检查），
+// 受限 DialContext 校验每个连接目标。
+func newImageDownloadClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy:       nil,
+			DialContext: dialRestricted,
+		},
+	}
+}
+
 // ImageURLCandidates 生成图片 URL 的候选解码变体。
 // QQ 图床 URL（multimedia.nt.qq.com.cn）在 CQ 码/JSON 里带 HTML 实体 &amp;，
 // 需先解码为 & 否则查询参数错乱、下载失败。
@@ -1180,9 +1236,10 @@ func DownloadImageBytes(ctx context.Context, rawURL string) ([]byte, error) {
 }
 
 // httpDownload 执行单次 HTTP GET 下载。
+// 使用受限客户端（SSRF 防护 + 禁用代理）；
 // Content-Length 预检 + LimitReader 双重限制响应体大小，防止 OOM。
 func httpDownload(ctx context.Context, u string) ([]byte, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := newImageDownloadClient()
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -1078,8 +1079,11 @@ func text_to_image(getT2I func() *t2icaller.Client) *onebotTool {
 
 // --- Vision / 识图 ---
 
-// vision 使用识图模型识别图片内容（imageModel 已配置版本）。
-func vision(imageModel provider.Provider) *onebotTool {
+// vision 使用识图模型识别图片内容。
+// imageModel 以 getter 传入：每次调用时实时 SelectModel(ModelTypeImage)，
+// 避免 Init 早期（loadProviders 之前）的快照为 nil 而注册成占位工具，
+// 也保证热更新 provider 后立即生效。
+func vision(getImageModel func() provider.Provider) *onebotTool {
 	input := NewToolInput{
 		id:   "",
 		name: "vision",
@@ -1106,6 +1110,16 @@ func vision(imageModel provider.Provider) *onebotTool {
 		if p.ImageURL == "" {
 			return "", fmt.Errorf("vision 缺少 image_url")
 		}
+		// 诊断：LLM 回传的 URL 可能与消息原文形态不同（HTML 实体/百分号编码/截断），
+		// 打印长度与前缀便于排查下载失败
+		urlPrefix := p.ImageURL
+		if len(urlPrefix) > 96 {
+			urlPrefix = urlPrefix[:96] + "..."
+		}
+		imageModel := getImageModel()
+		if imageModel == nil {
+			return "未配置识图模型(Image Model)，无法识别图片。请联系管理员配置。", nil
+		}
 		// 下载图片字节并交给识图模型
 		imgBytes, err := downloadBytes(ctx, p.ImageURL)
 		if err != nil {
@@ -1120,12 +1134,40 @@ func vision(imageModel provider.Provider) *onebotTool {
 }
 
 // downloadBytes 下载图片字节（vision 工具用）。
-func downloadBytes(ctx context.Context, url string) ([]byte, error) {
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		return nil, fmt.Errorf("仅支持 http(s) 图片 URL: %q", url)
+// QQ 图床 URL（multimedia.nt.qq.com.cn）在 CQ 码/JSON 里带 HTML 实体 &amp;，
+// 需先解码为 & 否则查询参数错乱、下载失败。
+// LLM 复刻 URL 时可能再次引入变形（百分号编码 %26、残留实体等），
+// 首次请求失败时依次尝试解码变体，任一成功即返回。
+func downloadBytes(ctx context.Context, rawURL string) ([]byte, error) {
+	candidates := []string{rawURL, strings.ReplaceAll(rawURL, "&amp;", "&")}
+	if u, err := url.QueryUnescape(rawURL); err == nil && u != rawURL {
+		candidates = append(candidates, u, strings.ReplaceAll(u, "&amp;", "&"))
 	}
+	var lastErr error
+	for i, u := range candidates {
+		if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+			lastErr = fmt.Errorf("仅支持 http(s) 图片 URL: %q", u)
+			continue
+		}
+		if i > 0 {
+			log.Info("vision 图片下载重试", "attempt", i+1, "url_len", len(u))
+		}
+		b, err := httpDownload(ctx, u)
+		if err == nil {
+			return b, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("图片 URL 无法解析: %q", rawURL)
+	}
+	return nil, lastErr
+}
+
+// httpDownload 执行单次 HTTP GET 下载。
+func httpDownload(ctx context.Context, u string) ([]byte, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1139,29 +1181,6 @@ func downloadBytes(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("图片下载 HTTP %d", resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
-}
-
-// vision_unavailable 未配置识图模型时的占位工具。
-func vision_unavailable() *onebotTool {
-	input := NewToolInput{
-		id:   "",
-		name: "vision",
-		desc: "识别图片内容",
-		params: openai.FunctionParameters{
-			"type": "object",
-			"properties": map[string]any{
-				"image_url": map[string]any{"type": "string", "description": "图片 URL"},
-				"prompt":    map[string]any{"type": "string", "description": "关于图片的问题"},
-			},
-			"required": []string{"image_url", "prompt"},
-		},
-		builtin:     true,
-		longRunning: false,
-	}
-	executer := func(ctx context.Context, args json.RawMessage) (string, error) {
-		return "未配置识图模型(Image Model)，无法识别图片。请联系管理员配置。", nil
-	}
-	return onebotToolBuild(executer, input)
 }
 
 // --- 会话信息 ---
@@ -1304,7 +1323,7 @@ func RegisterBuiltinTools(
 	adapter AdapterProvider,
 	getSandbox func() *sandboxcaller.Client,
 	getT2I func() *t2icaller.Client,
-	imageModel provider.Provider,
+	getImageModel func() provider.Provider,
 	getSessionCtx func(ctx context.Context) string,
 	getCurrentMsg func(ctx context.Context) *adapter.MessageEvent,
 	getRecentMsgs func(ctx context.Context, msgType string, targetID int64, limit int) ([]string, error),
@@ -1366,11 +1385,7 @@ func RegisterBuiltinTools(
 
 	// --- Vision / 识图 ---
 
-	if imageModel != nil {
-		tools = append(tools, vision(imageModel))
-	} else {
-		tools = append(tools, vision_unavailable())
-	}
+	tools = append(tools, vision(getImageModel))
 
 	// --- 会话信息 ---
 

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -1077,7 +1079,7 @@ func text_to_image(getT2I func() *t2icaller.Client) *onebotTool {
 // --- Vision / 识图 ---
 
 // vision 使用识图模型识别图片内容（imageModel 已配置版本）。
-func vision() *onebotTool {
+func vision(imageModel provider.Provider) *onebotTool {
 	input := NewToolInput{
 		id:   "",
 		name: "vision",
@@ -1094,9 +1096,49 @@ func vision() *onebotTool {
 		longRunning: false,
 	}
 	executer := func(ctx context.Context, args json.RawMessage) (string, error) {
-		return "识图功能需要图片字节数据，请通过其他方式获取图片后调用。", nil
+		var p struct {
+			ImageURL string `json:"image_url"`
+			Prompt   string `json:"prompt"`
+		}
+		if err := json.Unmarshal(args, &p); err != nil {
+			return "", fmt.Errorf("vision 参数解析失败: %w", err)
+		}
+		if p.ImageURL == "" {
+			return "", fmt.Errorf("vision 缺少 image_url")
+		}
+		// 下载图片字节并交给识图模型
+		imgBytes, err := downloadBytes(ctx, p.ImageURL)
+		if err != nil {
+			return "", fmt.Errorf("vision 图片下载失败: %w", err)
+		}
+		if p.Prompt == "" {
+			p.Prompt = "请描述这张图片的内容"
+		}
+		return imageModel.Vision(ctx, imgBytes, p.Prompt)
 	}
 	return onebotToolBuild(executer, input)
+}
+
+// downloadBytes 下载图片字节（vision 工具用）。
+func downloadBytes(ctx context.Context, url string) ([]byte, error) {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return nil, fmt.Errorf("仅支持 http(s) 图片 URL: %q", url)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; JuanNiang-Neo)")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("图片下载 HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
 }
 
 // vision_unavailable 未配置识图模型时的占位工具。
@@ -1325,7 +1367,7 @@ func RegisterBuiltinTools(
 	// --- Vision / 识图 ---
 
 	if imageModel != nil {
-		tools = append(tools, vision())
+		tools = append(tools, vision(imageModel))
 	} else {
 		tools = append(tools, vision_unavailable())
 	}

--- a/internal/agent/tool/builtin.go
+++ b/internal/agent/tool/builtin.go
@@ -1110,18 +1110,12 @@ func vision(getImageModel func() provider.Provider) *onebotTool {
 		if p.ImageURL == "" {
 			return "", fmt.Errorf("vision 缺少 image_url")
 		}
-		// 诊断：LLM 回传的 URL 可能与消息原文形态不同（HTML 实体/百分号编码/截断），
-		// 打印长度与前缀便于排查下载失败
-		urlPrefix := p.ImageURL
-		if len(urlPrefix) > 96 {
-			urlPrefix = urlPrefix[:96] + "..."
-		}
 		imageModel := getImageModel()
 		if imageModel == nil {
 			return "未配置识图模型(Image Model)，无法识别图片。请联系管理员配置。", nil
 		}
 		// 下载图片字节并交给识图模型
-		imgBytes, err := downloadBytes(ctx, p.ImageURL)
+		imgBytes, err := DownloadImageBytes(ctx, p.ImageURL)
 		if err != nil {
 			return "", fmt.Errorf("vision 图片下载失败: %w", err)
 		}
@@ -1133,16 +1127,37 @@ func vision(getImageModel func() provider.Provider) *onebotTool {
 	return onebotToolBuild(executer, input)
 }
 
-// downloadBytes 下载图片字节（vision 工具用）。
+// MaxImageBytes 图片下载的最大字节数，防止超大响应耗尽内存（OOM）。
+const MaxImageBytes = 25 << 20 // 25MB
+
+// ImageURLCandidates 生成图片 URL 的候选解码变体。
 // QQ 图床 URL（multimedia.nt.qq.com.cn）在 CQ 码/JSON 里带 HTML 实体 &amp;，
 // 需先解码为 & 否则查询参数错乱、下载失败。
 // LLM 复刻 URL 时可能再次引入变形（百分号编码 %26、残留实体等），
-// 首次请求失败时依次尝试解码变体，任一成功即返回。
-func downloadBytes(ctx context.Context, rawURL string) ([]byte, error) {
-	candidates := []string{rawURL, strings.ReplaceAll(rawURL, "&amp;", "&")}
-	if u, err := url.QueryUnescape(rawURL); err == nil && u != rawURL {
-		candidates = append(candidates, u, strings.ReplaceAll(u, "&amp;", "&"))
+// 生成原始、HTML 实体解码、百分号解码的组合变体供依次尝试。
+func ImageURLCandidates(rawURL string) []string {
+	var candidates []string
+	seen := make(map[string]struct{}, 4)
+	add := func(u string) {
+		if _, dup := seen[u]; dup {
+			return
+		}
+		seen[u] = struct{}{}
+		candidates = append(candidates, u)
 	}
+	add(rawURL)
+	add(strings.ReplaceAll(rawURL, "&amp;", "&"))
+	if u, err := url.QueryUnescape(rawURL); err == nil && u != rawURL {
+		add(u)
+		add(strings.ReplaceAll(u, "&amp;", "&"))
+	}
+	return candidates
+}
+
+// DownloadImageBytes 下载图片字节（vision 工具与群聊相关性识图共用）。
+// 依次尝试 URL 解码变体，任一成功即返回；带响应体大小上限。
+func DownloadImageBytes(ctx context.Context, rawURL string) ([]byte, error) {
+	candidates := ImageURLCandidates(rawURL)
 	var lastErr error
 	for i, u := range candidates {
 		if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
@@ -1150,7 +1165,7 @@ func downloadBytes(ctx context.Context, rawURL string) ([]byte, error) {
 			continue
 		}
 		if i > 0 {
-			log.Info("vision 图片下载重试", "attempt", i+1, "url_len", len(u))
+			log.Info("图片下载重试", "attempt", i+1, "url_len", len(u))
 		}
 		b, err := httpDownload(ctx, u)
 		if err == nil {
@@ -1165,6 +1180,7 @@ func downloadBytes(ctx context.Context, rawURL string) ([]byte, error) {
 }
 
 // httpDownload 执行单次 HTTP GET 下载。
+// Content-Length 预检 + LimitReader 双重限制响应体大小，防止 OOM。
 func httpDownload(ctx context.Context, u string) ([]byte, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
@@ -1176,11 +1192,21 @@ func httpDownload(ctx context.Context, u string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("图片下载 HTTP %d", resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	if resp.ContentLength > MaxImageBytes {
+		return nil, fmt.Errorf("图片过大: %d 字节（上限 %d）", resp.ContentLength, MaxImageBytes)
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, MaxImageBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > MaxImageBytes {
+		return nil, fmt.Errorf("图片过大: 超过 %d 字节上限", MaxImageBytes)
+	}
+	return b, nil
 }
 
 // --- 会话信息 ---

--- a/internal/agent/tool/image_download_test.go
+++ b/internal/agent/tool/image_download_test.go
@@ -84,7 +84,7 @@ func TestDialRestrictedRejectsLoopback(t *testing.T) {
 // 下载本地服务必须失败（SSRF 拒绝），防止攻击者借 vision 工具探测内部网络。
 func TestDownloadImageBytesRejectsLocalServer(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("internal data"))
+		_, _ = w.Write([]byte("internal data"))
 	}))
 	defer srv.Close()
 

--- a/internal/agent/tool/image_download_test.go
+++ b/internal/agent/tool/image_download_test.go
@@ -1,0 +1,44 @@
+package tool
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestImageURLCandidates 候选链覆盖：原始 → HTML 实体解码 → 百分号解码变体。
+// 群聊相关性识图与 vision 工具共用该候选逻辑，任一成功即下载成功。
+func TestImageURLCandidates(t *testing.T) {
+	raw := "https://multimedia.nt.qq.com.cn/download?appid=1407&amp;rkey=CAESM"
+	got := ImageURLCandidates(raw)
+	want := []string{
+		raw,
+		"https://multimedia.nt.qq.com.cn/download?appid=1407&rkey=CAESM",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("实体解码候选错误\n got: %v\nwant: %v", got, want)
+	}
+
+	// 百分号编码（LLM 复刻变形）：%26 应产生 QueryUnescape 变体
+	// （去重后：原始 + 解码，共 2 个候选）
+	encoded := "https://multimedia.nt.qq.com.cn/download?appid=1407%26rkey=x"
+	got = ImageURLCandidates(encoded)
+	if len(got) != 2 {
+		t.Fatalf("百分号编码候选数量错误: %d (%v)", len(got), got)
+	}
+	if got[1] != "https://multimedia.nt.qq.com.cn/download?appid=1407&rkey=x" {
+		t.Fatalf("QueryUnescape 变体缺失: %v", got)
+	}
+	// 原始 URL 必须始终是第一个候选（最优路径优先）
+	if got[0] != encoded {
+		t.Fatalf("原始 URL 应为首个候选: %v", got)
+	}
+}
+
+// TestImageURLCandidatesNoChange 无实体/无编码时不应产生重复候选。
+func TestImageURLCandidatesNoChange(t *testing.T) {
+	raw := "https://example.com/a.png"
+	got := ImageURLCandidates(raw)
+	if len(got) != 1 || got[0] != raw {
+		t.Fatalf("无变形 URL 应只有原始候选: %v", got)
+	}
+}

--- a/internal/agent/tool/image_download_test.go
+++ b/internal/agent/tool/image_download_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"net"
 	"reflect"
 	"testing"
 )
@@ -40,5 +41,26 @@ func TestImageURLCandidatesNoChange(t *testing.T) {
 	got := ImageURLCandidates(raw)
 	if len(got) != 1 || got[0] != raw {
 		t.Fatalf("无变形 URL 应只有原始候选: %v", got)
+	}
+}
+
+// TestBlockedIP SSRF 防护范围：loopback/私网/链路本地/组播/未指定/CGNAT 拒绝，
+// 公网地址放行。
+func TestBlockedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.1.1",
+		"169.254.1.1", "0.0.0.0", "100.64.1.1", "224.0.0.1",
+		"::1", "fe80::1", "fc00::1", "ff02::1",
+	}
+	for _, s := range blocked {
+		if !blockedIP(net.ParseIP(s)) {
+			t.Errorf("%s 应被 SSRF 防护拒绝", s)
+		}
+	}
+	allowed := []string{"8.8.8.8", "1.1.1.1", "2400:3200::1"}
+	for _, s := range allowed {
+		if blockedIP(net.ParseIP(s)) {
+			t.Errorf("%s 不应被 SSRF 防护拒绝", s)
+		}
 	}
 }

--- a/internal/agent/tool/image_download_test.go
+++ b/internal/agent/tool/image_download_test.go
@@ -1,8 +1,12 @@
 package tool
 
 import (
+	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -62,5 +66,33 @@ func TestBlockedIP(t *testing.T) {
 		if blockedIP(net.ParseIP(s)) {
 			t.Errorf("%s 不应被 SSRF 防护拒绝", s)
 		}
+	}
+}
+
+// TestDialRestrictedRejectsLoopback 受限拨号必须拒绝回环地址（SSRF 关键路径）。
+func TestDialRestrictedRejectsLoopback(t *testing.T) {
+	ctx := context.Background()
+	if _, err := dialRestricted(ctx, "tcp", "127.0.0.1:8080"); err == nil {
+		t.Fatal("回环地址应被拒绝")
+	}
+	if _, err := dialRestricted(ctx, "tcp", "[::1]:8080"); err == nil {
+		t.Fatal("IPv6 回环地址应被拒绝")
+	}
+}
+
+// TestDownloadImageBytesRejectsLocalServer 完整路径：httpDownload 经受限客户端
+// 下载本地服务必须失败（SSRF 拒绝），防止攻击者借 vision 工具探测内部网络。
+func TestDownloadImageBytesRejectsLocalServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("internal data"))
+	}))
+	defer srv.Close()
+
+	_, err := DownloadImageBytes(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("下载本地服务应被 SSRF 防护拒绝")
+	}
+	if !strings.Contains(err.Error(), "拒绝访问非公网地址") {
+		t.Fatalf("应返回 SSRF 拒绝错误, got: %v", err)
 	}
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -41,7 +41,7 @@ var (
 	ToolIsBuiltin           = Response{Status: 40030, Info: "内置工具运行时常驻, 不支持启停"}
 	InvalidPluginName       = Response{Status: 40045, Info: "插件名不合法（仅允许字母/数字/下划线/连字符）"}
 	PluginPackageUnsafe     = Response{Status: 40046, Info: "插件包包含非法路径（疑似 zip-slip 攻击）"}
-	TextProviderRequired    = Response{Status: 40047, Info: "至少保留一个启用的 Text 模型，无法停用或删除"}
+	TextProviderRequired    = Response{Status: 40047, Info: "至少保留一个启用的 Text 模型，无法停用、删除或变更"}
 	KnowledgeContentEmpty   = Response{Status: 40033, Info: "知识内容不能为空"}
 	ImageTooLarge           = Response{Status: 40034, Info: "图片大小不能超过 1.5MB"}
 	ImageTypeNotAllowed     = Response{Status: 40035, Info: "不支持的图片格式（仅支持 jpg/png/gif/webp）"}

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -41,6 +41,7 @@ var (
 	ToolIsBuiltin           = Response{Status: 40030, Info: "内置工具运行时常驻, 不支持启停"}
 	InvalidPluginName       = Response{Status: 40045, Info: "插件名不合法（仅允许字母/数字/下划线/连字符）"}
 	PluginPackageUnsafe     = Response{Status: 40046, Info: "插件包包含非法路径（疑似 zip-slip 攻击）"}
+	TextProviderRequired    = Response{Status: 40047, Info: "至少保留一个启用的 Text 模型，无法停用或删除"}
 	KnowledgeContentEmpty   = Response{Status: 40033, Info: "知识内容不能为空"}
 	ImageTooLarge           = Response{Status: 40034, Info: "图片大小不能超过 1.5MB"}
 	ImageTypeNotAllowed     = Response{Status: 40035, Info: "不支持的图片格式（仅支持 jpg/png/gif/webp）"}

--- a/internal/api/service/provider_tx_test.go
+++ b/internal/api/service/provider_tx_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"JuanNiang-Neo/internal/core/dao"
+)
+
+// TestIsDeadlockErr 结构化 SQLSTATE 判定：40P01/40001 命中，
+// 普通错误（含文本含 deadlock 字样）不命中，避免误触发事务重试。
+func TestIsDeadlockErr(t *testing.T) {
+	deadlocks := []*pgconn.PgError{
+		{Code: "40P01", Message: "deadlock detected"},
+		{Code: "40001", Message: "could not serialize access due to concurrent update"},
+	}
+	for _, pe := range deadlocks {
+		if !isDeadlockErr(pe) {
+			t.Errorf("SQLSTATE %s 应判定为可重试错误", pe.Code)
+		}
+	}
+	nonDeadlocks := []error{
+		&pgconn.PgError{Code: "23505", Message: "duplicate key"},
+		errors.New("deadlock detected in the text"),
+		errors.New("connection reset by peer"),
+		nil,
+	}
+	for _, err := range nonDeadlocks {
+		if isDeadlockErr(err) {
+			t.Errorf("错误不应判定为死锁: %v", err)
+		}
+	}
+}
+
+// newTxTestDB 构造 sqlite 内存库 + Service（仅 providerTx 使用 DAO.DB）。
+func newTxTestDB(t *testing.T) *Service {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	return &Service{DAO: dao.NewBundle(db)}
+}
+
+// TestProviderTxCtxCancel ctx 取消后不应继续发起新事务
+// （gorm 可能在事务开始前即拦截，fn 调用 0 或 1 次均可，但不得重试）。
+func TestProviderTxCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	s := newTxTestDB(t)
+	err := s.providerTx(ctx, func(tx *gorm.DB) error {
+		calls++
+		return &pgconn.PgError{Code: "40P01"}
+	})
+	if err == nil {
+		t.Fatal("ctx 已取消应返回错误")
+	}
+	if calls > 1 {
+		t.Fatalf("ctx 取消后不应重试, calls=%d", calls)
+	}
+}
+
+// TestProviderTxRetryBudget 死锁重试上限 3 次并带退避，不无限重试。
+func TestProviderTxRetryBudget(t *testing.T) {
+	start := time.Now()
+	calls := 0
+	s := newTxTestDB(t)
+	err := s.providerTx(context.Background(), func(tx *gorm.DB) error {
+		calls++
+		return &pgconn.PgError{Code: "40P01"}
+	})
+	if err == nil {
+		t.Fatal("应返回错误")
+	}
+	if calls != 3 {
+		t.Fatalf("重试次数应为 3, got %d", calls)
+	}
+	if time.Since(start) < 100*time.Millisecond {
+		t.Fatalf("重试间应有退避间隔, elapsed=%v", time.Since(start))
+	}
+}
+
+// TestProviderTxNonDeadlockNoRetry 非死锁错误立即返回，不重试。
+func TestProviderTxNonDeadlockNoRetry(t *testing.T) {
+	calls := 0
+	s := newTxTestDB(t)
+	err := s.providerTx(context.Background(), func(tx *gorm.DB) error {
+		calls++
+		return errors.New("connection reset by peer")
+	})
+	if err == nil || calls != 1 {
+		t.Fatalf("非死锁错误不应重试, calls=%d err=%v", calls, err)
+	}
+}

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 	"github.com/cloudwego/hertz/pkg/protocol/sse"
+	"github.com/jackc/pgx/v5/pgconn"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -372,25 +373,36 @@ func providerWriteErrResp(c *app.RequestContext, err error) {
 }
 
 // isDeadlockErr 判断是否为 Postgres 死锁/序列化失败（SQLSTATE 40P01 / 40001），
-// 这类错误可安全重试整个事务。
+// 这类错误可安全重试整个事务。使用结构化 *pgconn.PgError 判定，
+// 不依赖错误文本匹配，避免错误详情误触发重试。
 func isDeadlockErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "40P01") || strings.Contains(msg, "40001") ||
-		strings.Contains(msg, "deadlock detected") ||
-		strings.Contains(msg, "could not serialize access")
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "40P01" || pgErr.Code == "40001"
 }
 
-// providerTx 在事务内执行 fn；遇死锁/序列化冲突自动重试（最多 3 次）。
+// providerTx 在事务内执行 fn；遇死锁/序列化冲突时退避重试（最多 3 次）。
 // 事务闭包由 gorm DB.Transaction 管理：返回错误或 panic 时自动回滚，不泄漏连接。
+// 退避防止竞争事务同时重试互相踩踏；ctx 取消时立即终止，不再发起新事务。
 func (s *Service) providerTx(ctx context.Context, fn func(tx *gorm.DB) error) error {
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
 		err = s.DAO.DB.WithContext(ctx).Transaction(fn)
 		if !isDeadlockErr(err) {
 			return err
+		}
+		if attempt < 2 {
+			backoff := time.Duration(attempt+1) * 50 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
 		}
 	}
 	return err
@@ -469,11 +481,13 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 			return err
 		}
 		if data.IsActive {
-			// 获取当前 Provider 信息以确认类型（事务内，与写操作一致）
+			// 获取当前 Provider 信息以确认类型（事务内，与写操作一致）。
+			// 直接用 %w 包装原始错误：First 对"记录不存在"本就返回 gorm.ErrRecordNotFound，
+			// 连接错误/死锁（40P01）等不会被误判为 ProviderNotExist。
 			var err error
 			raw, err = txProvider.GetByID(ctx, id)
 			if err != nil {
-				return fmt.Errorf("%w: %v", gorm.ErrRecordNotFound, err)
+				return fmt.Errorf("获取 provider 失败: %w", err)
 			}
 			// 同类型只能有一个 Active：先停用同类型其他 Provider
 			if err := txProvider.DeactivateByType(ctx, raw.Type, id); err != nil {

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 	"github.com/cloudwego/hertz/pkg/protocol/sse"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 var log = logging.NewModule("api")
@@ -317,35 +318,23 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 	provType := provider.ModelType(data.Type)
 	providerConfig_ := provider.ProviderConfigFromModel(&providerConfig)
 
-	tx := s.DAO.DB.Begin()
-	if tx.Error != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
-		return
-	}
-	txProvider := s.DAO.Provider.WithTx(tx)
-	// 事务内行锁校验 + 写操作：并发请求无法同时通过校验并移除最后一个启用 Text Provider
-	if err := s.checkTextModelRemains(ctx, txProvider, id, &targetType, &targetActive); err != nil {
-		tx.Rollback()
-		providerWriteErrResp(c, err)
-		return
-	}
-
-	// 同类型只能有一个 Active：激活前先停用同类型其他 Provider
-	if data.IsActive {
-		if err := txProvider.DeactivateByType(ctx, data.Type, id); err != nil {
-			tx.Rollback()
-			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-			return
+	// 事务内行锁校验 + 写操作：并发请求无法同时通过校验并移除最后一个启用 Text Provider。
+	// 事务开头 ListForUpdate 锁定全部 Provider 行，与 Delete/Toggle 加锁顺序一致，避免死锁。
+	err := s.providerTx(ctx, func(tx *gorm.DB) error {
+		txProvider := s.DAO.Provider.WithTx(tx)
+		if err := s.checkTextModelRemains(ctx, txProvider, id, &targetType, &targetActive); err != nil {
+			return err
 		}
-	}
-
-	if err := txProvider.Update(ctx, &providerConfig); err != nil {
-		tx.Rollback()
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-		return
-	}
-	if err := tx.Commit().Error; err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		// 同类型只能有一个 Active：激活前先停用同类型其他 Provider
+		if data.IsActive {
+			if err := txProvider.DeactivateByType(ctx, data.Type, id); err != nil {
+				return err
+			}
+		}
+		return txProvider.Update(ctx, &providerConfig)
+	})
+	if err != nil {
+		providerWriteErrResp(c, err)
 		return
 	}
 
@@ -382,6 +371,31 @@ func providerWriteErrResp(c *app.RequestContext, err error) {
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(resp, dto.ErrorDetail{ErrorDetail: err.Error()}))
 }
 
+// isDeadlockErr 判断是否为 Postgres 死锁/序列化失败（SQLSTATE 40P01 / 40001），
+// 这类错误可安全重试整个事务。
+func isDeadlockErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "40P01") || strings.Contains(msg, "40001") ||
+		strings.Contains(msg, "deadlock detected") ||
+		strings.Contains(msg, "could not serialize access")
+}
+
+// providerTx 在事务内执行 fn；遇死锁/序列化冲突自动重试（最多 3 次）。
+// 事务闭包由 gorm DB.Transaction 管理：返回错误或 panic 时自动回滚，不泄漏连接。
+func (s *Service) providerTx(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		err = s.DAO.DB.WithContext(ctx).Transaction(fn)
+		if !isDeadlockErr(err) {
+			return err
+		}
+	}
+	return err
+}
+
 // checkTextModelRemains 校验停用/删除/更新操作后仍至少保留一个启用的 Text 模型。
 // Eino Agent 构建依赖 Text 模型：若全部停用，rebuild 报"无可用 Text 模型"、
 // 对话功能整体失能（历史故障）。targetType/targetActive 为操作后目标 provider
@@ -413,26 +427,16 @@ func (s *Service) checkTextModelRemains(ctx context.Context, p *dao.ProviderDAO,
 func (s *Service) DeleteProvider(ctx context.Context, c *app.RequestContext) {
 	id := c.Param("id")
 
-	tx := s.DAO.DB.Begin()
-	if tx.Error != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
-		return
-	}
-	txProvider := s.DAO.Provider.WithTx(tx)
 	// 事务内行锁校验 + 删除：并发请求无法同时通过校验并删除最后一个启用 Text Provider
-	if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
-		tx.Rollback()
+	err := s.providerTx(ctx, func(tx *gorm.DB) error {
+		txProvider := s.DAO.Provider.WithTx(tx)
+		if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
+			return err
+		}
+		return txProvider.Delete(ctx, id)
+	})
+	if err != nil {
 		providerWriteErrResp(c, err)
-		return
-	}
-
-	if err := txProvider.Delete(ctx, id); err != nil {
-		tx.Rollback()
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-		return
-	}
-	if err := tx.Commit().Error; err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
 		return
 	}
 
@@ -456,46 +460,39 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	tx := s.DAO.DB.Begin()
-	if tx.Error != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
-		return
-	}
-	txProvider := s.DAO.Provider.WithTx(tx)
-
 	var raw *models.Provider
-	if data.IsActive {
-		// 获取当前 Provider 信息以确认类型（事务内，与写操作一致）
-		var err error
-		raw, err = txProvider.GetByID(ctx, id)
-		if err != nil {
-			tx.Rollback()
+	err := s.providerTx(ctx, func(tx *gorm.DB) error {
+		txProvider := s.DAO.Provider.WithTx(tx)
+		// 统一加锁顺序：事务开头先锁定全部 Provider 行（与 Update/Delete 一致），
+		// 再执行 GetByID 与写操作，避免并发写路径形成循环等待（死锁）。
+		if _, err := txProvider.ListForUpdate(ctx, ""); err != nil {
+			return err
+		}
+		if data.IsActive {
+			// 获取当前 Provider 信息以确认类型（事务内，与写操作一致）
+			var err error
+			raw, err = txProvider.GetByID(ctx, id)
+			if err != nil {
+				return fmt.Errorf("%w: %v", gorm.ErrRecordNotFound, err)
+			}
+			// 同类型只能有一个 Active：先停用同类型其他 Provider
+			if err := txProvider.DeactivateByType(ctx, raw.Type, id); err != nil {
+				return err
+			}
+		} else {
+			// 停用前校验：至少保留一个启用的 Text 模型（事务内行锁校验 + 写操作）
+			if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
+				return err
+			}
+		}
+		return txProvider.SetActive(ctx, id, data.IsActive)
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ProviderNotExist, dto.ErrorDetail{ErrorDetail: err.Error()}))
 			return
 		}
-
-		// 同类型只能有一个 Active：先停用同类型其他 Provider
-		if err := txProvider.DeactivateByType(ctx, raw.Type, id); err != nil {
-			tx.Rollback()
-			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-			return
-		}
-	} else {
-		// 停用前校验：至少保留一个启用的 Text 模型（事务内行锁校验 + 写操作）
-		if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
-			tx.Rollback()
-			providerWriteErrResp(c, err)
-			return
-		}
-	}
-
-	if err := txProvider.SetActive(ctx, id, data.IsActive); err != nil {
-		tx.Rollback()
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-		return
-	}
-	if err := tx.Commit().Error; err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		providerWriteErrResp(c, err)
 		return
 	}
 

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -302,6 +302,14 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
 			return
 		}
+	} else {
+		// 停用/变更 text provider 前校验：至少保留一个启用的 Text 模型
+		targetType := provider.ModelType(data.Type)
+		targetActive := data.IsActive
+		if err := s.checkTextModelRemains(ctx, id, &targetType, &targetActive); err != nil {
+			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
+			return
+		}
 	}
 
 	providerConfig := models.Provider{
@@ -343,8 +351,40 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, nil))
 }
 
+// checkTextModelRemains 校验停用/删除/更新操作后仍至少保留一个启用的 Text 模型。
+// Eino Agent 构建依赖 Text 模型：若全部停用，rebuild 报"无可用 Text 模型"、
+// 对话功能整体失能（历史故障）。targetType/targetActive 为操作后目标 provider
+// 的预期状态；nil 表示目标将被删除或不再处于启用态。
+func (s *Service) checkTextModelRemains(ctx context.Context, id string, targetType *provider.ModelType, targetActive *bool) error {
+	list, err := s.DAO.Provider.List(ctx, "")
+	if err != nil {
+		return err
+	}
+	activeText := 0
+	for _, p := range list {
+		if p.ID == id {
+			continue
+		}
+		if p.IsActive && provider.ModelType(p.Type) == provider.ModelTypeText {
+			activeText++
+		}
+	}
+	if targetType != nil && *targetType == provider.ModelTypeText && targetActive != nil && *targetActive {
+		activeText++
+	}
+	if activeText == 0 {
+		return fmt.Errorf("至少保留一个启用的 Text 模型")
+	}
+	return nil
+}
+
 func (s *Service) DeleteProvider(ctx context.Context, c *app.RequestContext) {
 	id := c.Param("id")
+
+	if err := s.checkTextModelRemains(ctx, id, nil, nil); err != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
 
 	if err := s.DAO.Provider.Delete(ctx, id); err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
@@ -396,6 +436,10 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 			s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfigFromModel(raw)))
 		}
 	} else {
+		if err := s.checkTextModelRemains(ctx, id, nil, nil); err != nil {
+			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
+			return
+		}
 		if s.ProviderGroup != nil {
 			s.ProviderGroup.DelProvider(id)
 		}

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -296,21 +296,10 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	// 同类型只能有一个 Active：激活前先停用同类型其他 Provider
-	if data.IsActive {
-		if err := s.DAO.Provider.DeactivateByType(ctx, data.Type, id); err != nil {
-			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-			return
-		}
-	} else {
-		// 停用/变更 text provider 前校验：至少保留一个启用的 Text 模型
-		targetType := provider.ModelType(data.Type)
-		targetActive := data.IsActive
-		if err := s.checkTextModelRemains(ctx, id, &targetType, &targetActive); err != nil {
-			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
-			return
-		}
-	}
+	// 目标状态校验：激活、停用、变更类型都必须保证操作后至少保留一个启用的 Text 模型。
+	// 放在分支前：IsActive=true 且把最后一个 Text Provider 改为其他类型时同样拦截。
+	targetType := provider.ModelType(data.Type)
+	targetActive := data.IsActive
 
 	providerConfig := models.Provider{
 		ID:             id,
@@ -328,7 +317,39 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 	provType := provider.ModelType(data.Type)
 	providerConfig_ := provider.ProviderConfigFromModel(&providerConfig)
 
-	// 运行时同步：先移除同类型旧的，再同步新配置
+	tx := s.DAO.DB.Begin()
+	if tx.Error != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
+		return
+	}
+	txProvider := s.DAO.Provider.WithTx(tx)
+	// 事务内行锁校验 + 写操作：并发请求无法同时通过校验并移除最后一个启用 Text Provider
+	if err := s.checkTextModelRemains(ctx, txProvider, id, &targetType, &targetActive); err != nil {
+		tx.Rollback()
+		providerWriteErrResp(c, err)
+		return
+	}
+
+	// 同类型只能有一个 Active：激活前先停用同类型其他 Provider
+	if data.IsActive {
+		if err := txProvider.DeactivateByType(ctx, data.Type, id); err != nil {
+			tx.Rollback()
+			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+			return
+		}
+	}
+
+	if err := txProvider.Update(ctx, &providerConfig); err != nil {
+		tx.Rollback()
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+	if err := tx.Commit().Error; err != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+
+	// 运行时同步（DB 已提交，以 DB 为准）：先移除同类型旧的，再同步新配置
 	if s.ProviderGroup != nil {
 		if data.IsActive {
 			for _, p := range s.ProviderGroup.ListProviders() {
@@ -340,32 +361,43 @@ func (s *Service) UpdateProvider(ctx context.Context, c *app.RequestContext) {
 		s.ProviderGroup.SyncConfig(providerConfig_)
 	}
 
-	if err := s.DAO.Provider.Update(ctx, &providerConfig); err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-		return
-	}
-
 	// Provider 变更影响 Eino Agent 的 model adapter，必须重建
 	s.notifyRebuild()
 
 	c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.OK, nil))
 }
 
+// ErrTextModelRequired 是"操作后无启用 Text 模型"的业务哨兵错误。
+// 与 DAO 查询错误区分：仅该错误映射为 dto.TextProviderRequired（40047），
+// 其余（如 DB 故障）映射为 ServerInternalErr，避免客户端误判。
+var ErrTextModelRequired = errors.New("至少保留一个启用的 Text 模型")
+
+// providerWriteErrResp 统一 Provider 写操作失败响应：
+// 业务校验失败（ErrTextModelRequired）→ 40047；其他错误 → 500。
+func providerWriteErrResp(c *app.RequestContext, err error) {
+	resp := dto.ServerInternalErr
+	if errors.Is(err, ErrTextModelRequired) {
+		resp = dto.TextProviderRequired
+	}
+	c.JSON(consts.StatusOK, dto.GenFinalResponse(resp, dto.ErrorDetail{ErrorDetail: err.Error()}))
+}
+
 // checkTextModelRemains 校验停用/删除/更新操作后仍至少保留一个启用的 Text 模型。
 // Eino Agent 构建依赖 Text 模型：若全部停用，rebuild 报"无可用 Text 模型"、
 // 对话功能整体失能（历史故障）。targetType/targetActive 为操作后目标 provider
 // 的预期状态；nil 表示目标将被删除或不再处于启用态。
-func (s *Service) checkTextModelRemains(ctx context.Context, id string, targetType *provider.ModelType, targetActive *bool) error {
-	list, err := s.DAO.Provider.List(ctx, "")
+// p 应传入事务内 DAO（WithTx），以行锁（ListForUpdate）保证校验与写操作原子性。
+func (s *Service) checkTextModelRemains(ctx context.Context, p *dao.ProviderDAO, id string, targetType *provider.ModelType, targetActive *bool) error {
+	list, err := p.ListForUpdate(ctx, "")
 	if err != nil {
 		return err
 	}
 	activeText := 0
-	for _, p := range list {
-		if p.ID == id {
+	for _, pr := range list {
+		if pr.ID == id {
 			continue
 		}
-		if p.IsActive && provider.ModelType(p.Type) == provider.ModelTypeText {
+		if pr.IsActive && provider.ModelType(pr.Type) == provider.ModelTypeText {
 			activeText++
 		}
 	}
@@ -373,7 +405,7 @@ func (s *Service) checkTextModelRemains(ctx context.Context, id string, targetTy
 		activeText++
 	}
 	if activeText == 0 {
-		return fmt.Errorf("至少保留一个启用的 Text 模型")
+		return ErrTextModelRequired
 	}
 	return nil
 }
@@ -381,12 +413,25 @@ func (s *Service) checkTextModelRemains(ctx context.Context, id string, targetTy
 func (s *Service) DeleteProvider(ctx context.Context, c *app.RequestContext) {
 	id := c.Param("id")
 
-	if err := s.checkTextModelRemains(ctx, id, nil, nil); err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
+	tx := s.DAO.DB.Begin()
+	if tx.Error != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
+		return
+	}
+	txProvider := s.DAO.Provider.WithTx(tx)
+	// 事务内行锁校验 + 删除：并发请求无法同时通过校验并删除最后一个启用 Text Provider
+	if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
+		tx.Rollback()
+		providerWriteErrResp(c, err)
 		return
 	}
 
-	if err := s.DAO.Provider.Delete(ctx, id); err != nil {
+	if err := txProvider.Delete(ctx, id); err != nil {
+		tx.Rollback()
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+	if err := tx.Commit().Error; err != nil {
 		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
 		return
 	}
@@ -411,22 +456,52 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
+	tx := s.DAO.DB.Begin()
+	if tx.Error != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: tx.Error.Error()}))
+		return
+	}
+	txProvider := s.DAO.Provider.WithTx(tx)
+
+	var raw *models.Provider
 	if data.IsActive {
-		// 获取当前 Provider 信息以确认类型
-		raw, err := s.DAO.Provider.GetByID(ctx, id)
+		// 获取当前 Provider 信息以确认类型（事务内，与写操作一致）
+		var err error
+		raw, err = txProvider.GetByID(ctx, id)
 		if err != nil {
+			tx.Rollback()
 			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ProviderNotExist, dto.ErrorDetail{ErrorDetail: err.Error()}))
 			return
 		}
 
 		// 同类型只能有一个 Active：先停用同类型其他 Provider
-		if err := s.DAO.Provider.DeactivateByType(ctx, raw.Type, id); err != nil {
+		if err := txProvider.DeactivateByType(ctx, raw.Type, id); err != nil {
+			tx.Rollback()
 			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
 			return
 		}
+	} else {
+		// 停用前校验：至少保留一个启用的 Text 模型（事务内行锁校验 + 写操作）
+		if err := s.checkTextModelRemains(ctx, txProvider, id, nil, nil); err != nil {
+			tx.Rollback()
+			providerWriteErrResp(c, err)
+			return
+		}
+	}
 
-		// 运行时：移除同类型旧的，添加新的
-		if s.ProviderGroup != nil {
+	if err := txProvider.SetActive(ctx, id, data.IsActive); err != nil {
+		tx.Rollback()
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+	if err := tx.Commit().Error; err != nil {
+		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
+		return
+	}
+
+	// 运行时同步（DB 已提交，以 DB 为准）
+	if s.ProviderGroup != nil {
+		if data.IsActive {
 			provType := provider.ModelType(raw.Type)
 			for _, p := range s.ProviderGroup.ListProviders() {
 				if p.Type() == provType {
@@ -434,20 +509,9 @@ func (s *Service) ToggleProvider(ctx context.Context, c *app.RequestContext) {
 				}
 			}
 			s.ProviderGroup.AddProvider(provider.NewProvider(provider.ProviderConfigFromModel(raw)))
-		}
-	} else {
-		if err := s.checkTextModelRemains(ctx, id, nil, nil); err != nil {
-			c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.TextProviderRequired, dto.ErrorDetail{ErrorDetail: err.Error()}))
-			return
-		}
-		if s.ProviderGroup != nil {
+		} else {
 			s.ProviderGroup.DelProvider(id)
 		}
-	}
-
-	if err := s.DAO.Provider.SetActive(ctx, id, data.IsActive); err != nil {
-		c.JSON(consts.StatusOK, dto.GenFinalResponse(dto.ServerInternalErr, dto.ErrorDetail{ErrorDetail: err.Error()}))
-		return
 	}
 
 	// Provider 变更影响 Eino Agent 的 model adapter，必须重建

--- a/internal/core/dao/dao.go
+++ b/internal/core/dao/dao.go
@@ -29,6 +29,8 @@ func isDupKeyErr(err error) bool {
 
 // Bundle 汇聚所有 DAO，方便注入。
 type Bundle struct {
+	// DB 为底层 *gorm.DB 句柄，供 Service 层开启事务（配合各 DAO 的 WithTx）。
+	DB              *gorm.DB
 	User            *UserDAO
 	Provider        *ProviderDAO
 	MCPServer       *MCPServerDAO
@@ -61,6 +63,7 @@ type Bundle struct {
 
 func NewBundle(db *gorm.DB) *Bundle {
 	return &Bundle{
+		DB:              db,
 		User:            NewUserDAO(db),
 		Provider:        NewProviderDAO(db),
 		MCPServer:       NewMCPServerDAO(db),

--- a/internal/core/dao/providerDao.go
+++ b/internal/core/dao/providerDao.go
@@ -5,11 +5,28 @@ import (
 	"context"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type ProviderDAO struct{ db *gorm.DB }
 
 func NewProviderDAO(db *gorm.DB) *ProviderDAO { return &ProviderDAO{db: db} }
+
+// WithTx 返回绑定到指定事务的 DAO 副本，供 Service 层在事务内执行校验与写操作。
+func (d *ProviderDAO) WithTx(tx *gorm.DB) *ProviderDAO { return &ProviderDAO{db: tx} }
+
+// ListForUpdate 行级锁查询 Provider 列表（SELECT ... FOR UPDATE），
+// 用于事务内校验"至少保留一个启用 Text 模型"不变量：并发写事务会阻塞在锁上，
+// 提交后重查拿到最新数据，避免校验通过后写操作破坏不变量。
+func (d *ProviderDAO) ListForUpdate(ctx context.Context, typ models.ModelType) ([]models.Provider, error) {
+	var list []models.Provider
+	q := d.db.WithContext(ctx).Clauses(clause.Locking{Strength: "UPDATE"})
+	if typ != "" {
+		q = q.Where("type = ?", typ)
+	}
+	err := q.Order("created_at DESC").Find(&list).Error
+	return list, err
+}
 
 func (d *ProviderDAO) Create(ctx context.Context, p *models.Provider) error {
 	if p.ID == "" {


### PR DESCRIPTION
## 背景
群聊图片消息无法被识别（私聊正常）。排查发现三个根因叠加。

## 变更
### 1. vision 工具 imageModel nil 快照
`RegisterBuiltinTools` 在 `loadProviders` **之前**调用，传入 `SelectModel(ModelTypeImage)` 为 nil 的即时快照 → vision 工具被注册成占位（返回"未配置识图模型"）。改为传 getter，调用时实时解析 imageModel，Init 时序不再影响，热更新 provider 立即生效。

### 2. QQ 图床 URL `&amp;` 实体 + LLM 复刻变形
QQ CDN URL（`multimedia.nt.qq.com.cn`）在 CQ 消息里带 HTML 实体 `&amp;`，LLM 复刻 URL 时进一步变形（百分号编码 `%26`），导致下载返回 HTTP 400 `invalid rkey`。
- 事件侧：发给 LLM 的用户消息文本解码 `&amp;`→`&`（存储记录保留原文）
- 下载侧：`downloadBytes` 失败后依次尝试 percent-unescape 变体
- `fetchImageBytes` 同样先解码

### 3. selfID 多连接随机
`isAtSelf` 依赖 `Adapter.SelfID()`，其遍历 map 返回第一个（多 WS 连接时随机），`at_only` 策略可能丢弃带 @ 的群消息。改为优先使用事件自带的 `self_id`，确定性匹配。`at_only` 丢弃日志升到 Info 便于观测。

## 验证
- `go test ./internal/agent/ ./internal/pluggin/` 全绿
- wsprobe 发送真实 QQ CDN 图片 URL + @ 的群消息：完整走通 → vision 调用 → 识图成功（1481B）→ 群回复 3 段成功
- 用户真实私聊/群聊图片消息均正常识图

## 附注
依赖前置提交：Provider 防呆（禁用最后一个 text provider 的 40047 防护）与图片字节下载，均为本分支的一部分。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 视觉模型支持动态切换，并可通过 HTTP(S) 图片 URL 或本地图片路径进行识图。
  - 支持常见 URL 变体，单张图片大小限制为 25MB。
  - 群聊“仅@我回复”可更准确识别当前机器人身份。
  - 图片内容中的 HTML 转义字符将正确还原，普通文本不受影响。

- **改进**
  - 图片下载增加公网地址校验，降低潜在网络安全风险。
  - 停用或删除最后一个启用的文本模型时将被阻止并提示原因。
  - 图片下载失败或识图模型不可用时，将按配置进行降级处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->