### PR TITLE
feat(web): 新增深浅色主题切换，修复摸鱼人日历月末日期溢出

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app theme="JuanNiangThemeDark">
+  <v-app :theme="themeStore.effectiveThemeName">
     <RouterView />
 
     <v-snackbar v-if="toastStore.show" v-model="toastStore.show" :color="toastStore.current?.color"
@@ -21,6 +21,8 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
 import { useToastStore } from '@/stores/toast'
+import { useThemeStore } from '@/stores/theme'
 
 const toastStore = useToastStore()
+const themeStore = useThemeStore()
 </script>

--- a/web/src/components/shared/ThemeModeMenu.vue
+++ b/web/src/components/shared/ThemeModeMenu.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-menu location="bottom end" offset="8" :close-on-content-click="true">
+    <template #activator="{ props }">
+      <v-btn
+        v-bind="props"
+        icon
+        variant="text"
+        size="small"
+        class="theme-mode-trigger"
+        aria-label="切换主题"
+      >
+        <v-icon size="20">{{ effectiveIcon }}</v-icon>
+      </v-btn>
+    </template>
+
+    <v-card rounded="lg" min-width="176" elevation="8" class="theme-mode-menu">
+      <v-list density="compact" class="pa-1" aria-label="主题模式">
+        <v-list-item
+          prepend-icon="mdi-brightness-auto"
+          title="跟随系统"
+          :active="store.mode === 'system'"
+          :append-icon="store.mode === 'system' ? 'mdi-check' : undefined"
+          active-color="primary"
+          class="theme-mode-item"
+          @click="store.setMode('system')"
+        />
+        <v-list-item
+          prepend-icon="mdi-weather-night"
+          title="深色"
+          :active="store.mode === 'dark'"
+          :append-icon="store.mode === 'dark' ? 'mdi-check' : undefined"
+          active-color="primary"
+          class="theme-mode-item"
+          @click="store.setMode('dark')"
+        />
+        <v-list-item
+          prepend-icon="mdi-white-balance-sunny"
+          title="浅色"
+          :active="store.mode === 'light'"
+          :append-icon="store.mode === 'light' ? 'mdi-check' : undefined"
+          active-color="primary"
+          class="theme-mode-item"
+          @click="store.setMode('light')"
+        />
+      </v-list>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useThemeStore } from '@/stores/theme'
+
+const store = useThemeStore()
+
+// 触发器图标随「生效模式」显示（跟随系统时也显示实际生效的图标）
+const effectiveIcon = computed(() =>
+  store.effectiveDark ? 'mdi-weather-night' : 'mdi-white-balance-sunny',
+)
+</script>
+
+<style scoped>
+.theme-mode-item {
+  border-radius: 8px;
+  min-height: 38px;
+}
+</style>

--- a/web/src/layouts/AppHeader.vue
+++ b/web/src/layouts/AppHeader.vue
@@ -20,6 +20,9 @@
       <span class="hidden-xs">刷新数据</span>
     </v-btn>
 
+    <!-- 主题模式切换：跟随系统 / 深色 / 浅色 -->
+    <ThemeModeMenu class="me-2" />
+
     <v-menu offset="12" location="bottom end">
       <template #activator="{ props }">
         <v-btn v-bind="props" variant="text" class="me-3" style="min-width: 0; padding: 0 6px; height: 46px">
@@ -49,6 +52,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
+import ThemeModeMenu from '@/components/shared/ThemeModeMenu.vue'
 
 const router = useRouter()
 const appStore = useAppStore()

--- a/web/src/layouts/AppSidebar.vue
+++ b/web/src/layouts/AppSidebar.vue
@@ -11,12 +11,12 @@
     <div class="d-flex align-center ps-4 pe-3 py-3" style="min-height: 64px; gap: 10px; flex-shrink: 0">
       <img v-if="logoExists" src="/site_logo.png" alt="Logo" style="height: 30px; width: 30px; border-radius: 8px; flex-shrink: 0" @error="logoExists = false" />
       <div class="d-flex flex-column" style="line-height: 1.1">
-        <span class="font-weight-bold" style="color: rgba(255,255,255,0.92); font-size: 15px; white-space: nowrap">JuanNiang-Neo</span>
-        <span class="text-caption" style="color: rgba(255,255,255,0.35); font-size: 11px">智能管理控制台</span>
+        <span class="font-weight-bold" style="color: rgb(var(--v-theme-on-surface)); font-size: 15px; white-space: nowrap">JuanNiang-Neo</span>
+        <span class="text-caption" style="color: rgba(var(--v-theme-on-surface), 0.55); font-size: 11px">智能管理控制台</span>
       </div>
     </div>
 
-    <v-divider class="mx-3" style="border-color: rgba(255,255,255,0.06); flex-shrink: 0" />
+    <v-divider class="mx-3" style="border-color: rgba(var(--v-theme-on-surface), 0.08); flex-shrink: 0" />
 
     <!-- Collapsible nav groups -->
     <!-- Navigation scrolls independently so flex sizing does not clip it. -->
@@ -49,8 +49,8 @@
     </div>
 
     <div class="px-3 py-2 flex-shrink-0">
-      <v-divider style="border-color: rgba(255,255,255,0.06)" class="mb-2" />
-      <div class="text-caption px-3 py-2" style="color: rgba(255,255,255,0.28); font-size: 11px">
+      <v-divider style="border-color: rgba(var(--v-theme-on-surface), 0.08)" class="mb-2" />
+      <div class="text-caption px-3 py-2" style="color: rgba(var(--v-theme-on-surface), 0.45); font-size: 11px">
         JuanNiang-Neo v1.0.0
       </div>
     </div>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -3,10 +3,14 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import vuetify from './plugins/vuetify'
+import { useThemeStore } from './stores/theme'
 import './scss/style.scss'
 
 const app = createApp(App)
-app.use(createPinia())
+const pinia = createPinia()
+app.use(pinia)
+// 先实例化主题 store：同步应用 <html data-theme> 与 color-scheme，避免挂载前闪烁
+useThemeStore(pinia)
 app.use(router)
 app.use(vuetify)
 app.mount('#app')

--- a/web/src/scss/components/_shared.scss
+++ b/web/src/scss/components/_shared.scss
@@ -62,7 +62,7 @@
 
 /* ===== 代码块 ===== */
 .code-block {
-  background: rgba(0, 0, 0, 0.25);
+  background: rgb(var(--v-theme-code-bg));
   border: 1px solid rgba(var(--v-theme-on-surface), 0.1);
   border-radius: 10px;
   padding: 16px;
@@ -71,7 +71,7 @@
   overflow-x: auto;
   max-height: 300px;
   overflow-y: auto;
-  color: #cbd5e1;
+  color: rgb(var(--v-theme-code-fg));
 }
 
 /* ===== 空状态 ===== */
@@ -103,117 +103,4 @@
     letter-spacing: -0.2px;
     user-select: none;
   }
-}
-
-/* ===== 登录页（现代控制台） ===== */
-.login-page {
-  min-height: 100vh;
-  display: flex;
-  align-items: stretch;
-  background: radial-gradient(1200px 600px at 15% -10%, rgba(99, 102, 241, 0.18), transparent 60%),
-              radial-gradient(900px 500px at 110% 110%, rgba(139, 92, 246, 0.16), transparent 55%),
-              linear-gradient(160deg, #0b0d14 0%, #0e1117 55%, #0b0d14 100%);
-  position: relative;
-  overflow: hidden;
-
-  .login-decor {
-    position: absolute; pointer-events: none;
-    &.circle-1 {
-      width: 340px; height: 340px; border-radius: 50%;
-      background: radial-gradient(circle, rgba(99, 102, 241, 0.14), transparent 70%);
-      top: -100px; right: -80px;
-    }
-    &.circle-2 {
-      width: 260px; height: 260px; border-radius: 50%;
-      background: radial-gradient(circle, rgba(139, 92, 246, 0.1), transparent 70%);
-      bottom: -60px; left: -60px;
-    }
-    &.circle-3 {
-      width: 180px; height: 180px; border-radius: 50%;
-      background: radial-gradient(circle, rgba(96, 165, 250, 0.08), transparent 70%);
-      top: 40%; left: 6%;
-    }
-    &.line-dots {
-      top: 12%; right: 8%;
-      display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
-      span { width: 4px; height: 4px; border-radius: 50%; background: rgba(99, 102, 241, 0.28); }
-    }
-  }
-
-  .login-banner-wrapper {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 48px;
-    position: relative;
-
-    &::before {
-      content: '';
-      position: absolute;
-      width: 360px; height: 360px;
-      border-radius: 50%;
-      background: radial-gradient(circle, rgba(99, 102, 241, 0.1), transparent 70%);
-      top: 50%; left: 50%;
-      transform: translate(-50%, -50%);
-      pointer-events: none;
-    }
-
-    .login-banner-frame {
-      position: relative;
-      border-radius: 24px;
-      padding: 6px;
-      background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(139, 92, 246, 0.25));
-      box-shadow: 0 32px 64px rgba(0, 0, 0, 0.4), 0 0 80px rgba(99, 102, 241, 0.1);
-      img {
-        display: block;
-        max-width: 440px;
-        max-height: 70vh;
-        border-radius: 20px;
-        object-fit: cover;
-      }
-    }
-  }
-
-  .login-form-container {
-    width: 440px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: 56px 44px;
-    background: rgba(14, 17, 23, 0.7);
-    backdrop-filter: blur(20px);
-    border-left: 1px solid rgba(255, 255, 255, 0.06);
-    position: relative;
-    z-index: 1;
-
-    .login-logo {
-      margin-bottom: 6px;
-      .logo-row {
-        display: flex; align-items: center; gap: 14px; margin-bottom: 4px;
-        img { width: 46px; height: 46px; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
-      }
-      h1 { font-size: 28px; font-weight: 700; color: #fff; margin: 0 0 6px; letter-spacing: -0.5px; }
-      p  { color: rgba(255, 255, 255, 0.45); font-size: 14px; margin: 0; }
-    }
-
-    .login-btn {
-      height: 50px !important;
-      font-size: 15px !important;
-      font-weight: 600 !important;
-      letter-spacing: 0.5px !important;
-      background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%) !important;
-      border-radius: 12px !important;
-      box-shadow: 0 8px 24px rgba(99, 102, 241, 0.35) !important;
-      &:hover {
-        box-shadow: 0 12px 32px rgba(99, 102, 241, 0.5) !important;
-        transform: translateY(-1px);
-      }
-    }
-  }
-}
-
-@media (max-width: 960px) {
-  .login-page .login-banner-wrapper { display: none; }
-  .login-page .login-form-container  { width: 100%; padding: 40px 24px; }
 }

--- a/web/src/scss/layout/_sidebar.scss
+++ b/web/src/scss/layout/_sidebar.scss
@@ -29,7 +29,7 @@
 
     &:hover {
       background: rgba(var(--v-theme-primary), 0.08) !important;
-      color: rgb(var(--v-theme-on-surface)) !important;
+      color: rgb(var(--v-theme-sidebar-hover-text)) !important;
     }
 
     &.v-list-item--active {
@@ -72,7 +72,7 @@
 
       &:hover {
         background: rgba(var(--v-theme-primary), 0.08) !important;
-        color: rgb(var(--v-theme-on-surface)) !important;
+        color: rgb(var(--v-theme-sidebar-hover-text)) !important;
       }
     }
 

--- a/web/src/scss/style.scss
+++ b/web/src/scss/style.scss
@@ -48,6 +48,10 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* 挂载前/滚动越界的底色与主题一致（data-theme 由 stores/theme.ts 同步） */
+html[data-theme='dark'] { background: #0b0d14; }
+html[data-theme='light'] { background: #f5f6fa; }
+
 /* 细滚动条 */
 ::-webkit-scrollbar {
   width: 8px;

--- a/web/src/stores/theme.ts
+++ b/web/src/stores/theme.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+import { computed, ref, watch } from 'vue'
+
+export type ThemeMode = 'system' | 'dark' | 'light'
+
+const STORAGE_KEY = 'theme-mode'
+
+function loadMode(): ThemeMode {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  return raw === 'dark' || raw === 'light' || raw === 'system' ? raw : 'system'
+}
+
+/**
+ * 深浅色模式：跟随系统 / 深色 / 浅色。
+ * 用户选择持久化到 localStorage（theme-mode），并同步到
+ * <html data-theme="dark|light"> 与 color-scheme（供原生滚动条/表单控件匹配）。
+ */
+export const useThemeStore = defineStore('theme', () => {
+  const mode = ref<ThemeMode>(loadMode())
+  const systemDark = ref(window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+  const systemQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  systemQuery.addEventListener('change', (e: MediaQueryListEvent) => {
+    systemDark.value = e.matches
+  })
+
+  // 生效的模式（'system' 时按系统偏好解析）
+  const effectiveDark = computed(
+    () => (mode.value === 'system' ? systemDark.value : mode.value === 'dark'),
+  )
+  const effectiveThemeName = computed(
+    () => (effectiveDark.value ? 'JuanNiangThemeDark' : 'JuanNiangTheme'),
+  )
+
+  function applyDocument() {
+    const dark = effectiveDark.value
+    document.documentElement.dataset.theme = dark ? 'dark' : 'light'
+    document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+  }
+
+  function setMode(next: ThemeMode) {
+    mode.value = next
+    localStorage.setItem(STORAGE_KEY, next)
+    applyDocument()
+  }
+
+  // 跟随系统时，系统偏好变化也要同步 <html data-theme> 与 color-scheme
+  watch(effectiveDark, applyDocument)
+
+  // store 实例化时立即同步一次文档状态（main.ts 中先于挂载调用，避免闪烁）
+  applyDocument()
+
+  return { mode, effectiveDark, effectiveThemeName, setMode }
+})

--- a/web/src/theme/codemirrorTheme.ts
+++ b/web/src/theme/codemirrorTheme.ts
@@ -1,0 +1,54 @@
+import { EditorView } from '@codemirror/view'
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import { tags } from '@lezer/highlight'
+import type { Extension } from '@codemirror/state'
+
+/**
+ * 随主题自动适配的 CodeMirror 主题。
+ * 所有颜色引用 Vuetify 的 `--v-theme-code-*` CSS 变量——切换深浅色时变量变化，
+ * CodeMirror 通过 var() 自动跟随，无需 JS 监听或重建编辑器。
+ * 用法：`cmExtensions = [basicSetup, json(), ...cmCodeMirrorTheme()]`
+ */
+export function cmCodeMirrorTheme(): Extension[] {
+  return [
+    EditorView.theme({
+      '&': {
+        backgroundColor: 'rgb(var(--v-theme-code-bg))',
+        color: 'rgb(var(--v-theme-code-fg))',
+      },
+      '&.cm-focused': { outline: 'none' },
+      '.cm-content': {
+        fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+        fontSize: '13px',
+      },
+      '.cm-scroller': {
+        fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+        fontSize: '13px',
+      },
+      '.cm-gutters': {
+        backgroundColor: 'rgb(var(--v-theme-code-bg))',
+        color: 'rgba(var(--v-theme-code-fg), 0.55)',
+        borderRight: '1px solid rgba(var(--v-theme-code-fg), 0.18)',
+      },
+      '.cm-activeLine': { backgroundColor: 'rgba(var(--v-theme-code-fg), 0.06)' },
+      '.cm-activeLineGutter': {
+        backgroundColor: 'rgba(var(--v-theme-code-fg), 0.08)',
+        color: 'rgb(var(--v-theme-code-fg))',
+      },
+      '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
+        backgroundColor: 'rgba(var(--v-theme-primary), 0.28)',
+      },
+      '.cm-cursor': { borderLeftColor: 'rgb(var(--v-theme-primary))' },
+      '.cm-placeholder': { color: 'rgba(var(--v-theme-code-fg), 0.45)' },
+      '&.cm-focused .cm-selectionBackground': { backgroundColor: 'rgba(var(--v-theme-primary), 0.28)' },
+    }),
+    syntaxHighlighting(
+      HighlightStyle.define([
+        { tag: tags.propertyName, color: 'rgb(var(--v-theme-code-property))' },
+        { tag: tags.string, color: 'rgb(var(--v-theme-code-string))' },
+        { tag: [tags.number, tags.bool, tags.null, tags.atom], color: 'rgb(var(--v-theme-code-number))' },
+        { tag: tags.comment, color: 'rgb(var(--v-theme-code-comment))', fontStyle: 'italic' },
+      ]),
+    ),
+  ]
+}

--- a/web/src/theme/theme.ts
+++ b/web/src/theme/theme.ts
@@ -1,7 +1,8 @@
 import type { ThemeDefinition } from 'vuetify'
 
-// Shared across both themes — 语义色（现代控制台）
+// 两主题共用的语义色——统计/状态色，两态取值一致。
 const sharedColors = {
+  // 统计/状态色（stat-*：图标底、状态点等），品牌级语义，两态通用
   'stat-pink': '#ff5c8a',
   'stat-blue': '#60a5fa',
   'stat-green': '#34d399',
@@ -31,25 +32,34 @@ export const JuanNiangThemeDark: ThemeDefinition = {
     'info': '#60a5fa',
     'success': '#34d399',
     'warning': '#fbbf24',
+    // 侧边栏：深色面板（深色模式）
     'sidebar-bg': '#0e1117',
     'sidebar-text': '#8b93a5',
+    'sidebar-hover-text': '#e8ecf4',
     'header-bg': '#0e1117',
     'card-bg': '#171b25',
+    // 代码区（CodeMirror / .code-block / 日志与 Prompt 代码框）：深色面板 + GitHub-dark 语法色
+    'code-bg': '#161b22',
+    'code-fg': '#cbd5e1',
+    'code-property': '#79c0ff',
+    'code-string': '#a5d6ff',
+    'code-number': '#ffab70',
+    'code-comment': '#8b949e',
   },
 }
 
-// 亮色主题 — 干净的白底 + 同色系主色
+// 亮色主题 — 清透冷白 + 靛蓝主色（同品牌色系），MD3 分层的 surface 层级
 export const JuanNiangTheme: ThemeDefinition = {
   dark: false,
   colors: {
     ...sharedColors,
-    'background': '#f4f5fb',
+    'background': '#f5f6fa',
     'surface': '#ffffff',
     'surface-bright': '#ffffff',
-    'surface-light': '#fafbff',
-    'surface-variant': '#eef1f8',
-    'on-surface': '#1a2233',
-    'on-surface-variant': '#5b6472',
+    'surface-light': '#fbfcfe',
+    'surface-variant': '#eceef5',
+    'on-surface': '#1b2233',
+    'on-surface-variant': '#5d6678',
     'primary': '#4f46e5',
     'primary-darken-1': '#4338ca',
     'secondary': '#64748b',
@@ -59,9 +69,18 @@ export const JuanNiangTheme: ThemeDefinition = {
     'info': '#2563eb',
     'success': '#059669',
     'warning': '#d97706',
-    'sidebar-bg': '#0e1117',
-    'sidebar-text': '#a3abc0',
+    // 侧边栏：白色面板（浅色模式，与 header/卡片同色系）
+    'sidebar-bg': '#ffffff',
+    'sidebar-text': '#475569',
+    'sidebar-hover-text': '#1b2233',
     'header-bg': '#ffffff',
     'card-bg': '#ffffff',
+    // 代码区：浅色面板 + GitHub-light 语法色（深浅切换时随 CSS 变量自动更新）
+    'code-bg': '#f6f8fa',
+    'code-fg': '#24292f',
+    'code-property': '#0550ae',
+    'code-string': '#0a3069',
+    'code-number': '#116329',
+    'code-comment': '#6e7781',
   },
 }

--- a/web/src/views/CronJobsPage.vue
+++ b/web/src/views/CronJobsPage.vue
@@ -102,6 +102,7 @@ import { basicSetup } from 'codemirror'
 import { cronJobApi, type CronJobResp, type AddCronJobReq } from '@/api'
 import { pluginApi } from '@/api'
 import { useToastStore } from '@/stores/toast'
+import { cmCodeMirrorTheme } from '@/theme/codemirrorTheme'
 
 const toastStore = useToastStore()
 const loading = ref(true)
@@ -127,8 +128,8 @@ const defaultForm = (): AddCronJobReq => ({
 
 const form = ref<AddCronJobReq>(defaultForm())
 
-// CodeMirror 配置
-const cmExtensions = [basicSetup, json()]
+// CodeMirror 配置（主题随深浅色自动适配）
+const cmExtensions = [basicSetup, json(), ...cmCodeMirrorTheme()]
 
 // JSON payload 实时校验
 const payloadError = computed(() => {
@@ -209,14 +210,5 @@ onMounted(fetch)
 }
 .editor-wrapper :deep(.cm-focused) {
   outline: none !important;
-}
-.editor-wrapper :deep(.cm-gutters) {
-  background: #000 !important;
-  color: #888 !important;
-  border-right: 1px solid #333 !important;
-}
-.editor-wrapper :deep(.cm-activeLineGutter) {
-  background: #1a1a1a !important;
-  color: #ccc !important;
 }
 </style>

--- a/web/src/views/DashboardPage.vue
+++ b/web/src/views/DashboardPage.vue
@@ -93,21 +93,21 @@
                       <span>内存使用</span>
                       <span class="progress-val">{{ heapMB }} MB</span>
                     </div>
-                    <v-progress-linear :model-value="heapPct" height="8" rounded color="#818cf8" bg-color="rgba(255,255,255,0.08)" />
+                    <v-progress-linear :model-value="heapPct" height="8" rounded color="#818cf8" :bg-color="trackColor" />
                   </div>
                   <div class="progress-item">
                     <div class="progress-head">
                       <span>内存分配</span>
                       <span class="progress-val">{{ allocMB }} MB</span>
                     </div>
-                    <v-progress-linear :model-value="allocPct" height="8" rounded color="#34d399" bg-color="rgba(255,255,255,0.08)" />
+                    <v-progress-linear :model-value="allocPct" height="8" rounded color="#34d399" :bg-color="trackColor" />
                   </div>
                   <div class="progress-item">
                     <div class="progress-head">
                       <span>CPU 核数</span>
                       <span class="progress-val">{{ cpuCount }} 核</span>
                     </div>
-                    <v-progress-linear :model-value="cpuPct" height="8" rounded color="#60a5fa" bg-color="rgba(255,255,255,0.08)" />
+                    <v-progress-linear :model-value="cpuPct" height="8" rounded color="#60a5fa" :bg-color="trackColor" />
                   </div>
                 </div>
               </div>
@@ -195,17 +195,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
 import { init, use, type EChartsType } from 'echarts/core'
 import { LineChart, GaugeChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
+import { useTheme } from 'vuetify'
 import { overviewApi, adapterApi, type OverviewResp, type AdapterStatus, type DailyTokenUsageResp } from '@/api'
 import { useToastStore } from '@/stores/toast'
 
 use([LineChart, GaugeChart, GridComponent, TooltipComponent, CanvasRenderer])
 
 const toastStore = useToastStore()
+const theme = useTheme()
 const loading = ref(true)
 const overview = ref<OverviewResp | null>(null)
 const adapterRunning = ref(false)
@@ -219,6 +221,35 @@ let chart: EChartsType | null = null
 // 系统资源：Goroutine 仪表盘
 const goroutineGaugeEl = ref<HTMLDivElement | null>(null)
 let goroutineGaugeChart: EChartsType | null = null
+
+// ===== 主题感知的图表色 =====
+// 从 Vuetify 当前主题的 token 取色，深浅切换时图表随之更新（ECharts 无法直接用 CSS var）
+function hexToRgb(hex: string): string {
+  const short = hex.replace('#', '')
+  const full = short.length === 3 ? short.split('').map(c => c + c).join('') : short
+  const n = parseInt(full, 16)
+  return `${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}`
+}
+function inkColor(alpha: number): string {
+  const onSurface = theme.global.current.value.colors['on-surface']
+  return `rgba(${hexToRgb(onSurface)}, ${alpha})`
+}
+function tokenColor(name: string): string {
+  return theme.global.current.value.colors[name] ?? '#6366f1'
+}
+// 进度条轨道色：随主题在浅底/深底上都可辨
+const trackColor = computed(() => `rgba(${hexToRgb(theme.global.current.value.colors['on-surface'])}, 0.12)`)
+
+const lastTokenData = ref<DailyTokenUsageResp[]>([])
+
+// 主题切换后重绘两张图
+watch(
+  () => theme.global.name.value,
+  () => {
+    if (lastTokenData.value.length) renderTokenChart(lastTokenData.value)
+    if (goroutineGaugeEl.value) renderGauges()
+  },
+)
 
 // 系统资源进度条数据（内存使用显示数值，非百分比）
 const heapMB = computed(() => Math.round((overview.value?.mem_heap_inuse_bytes ?? 0) / 1048576))
@@ -244,6 +275,8 @@ async function fetchTokenUsage() {
 function renderTokenChart(list: DailyTokenUsageResp[]) {
   if (!chartEl.value) return
   if (!chart) chart = init(chartEl.value)
+  lastTokenData.value = list
+  const primary = tokenColor('primary')
   chart.setOption({
     grid: { left: 16, right: 16, top: 36, bottom: 8, containLabel: true },
     tooltip: { trigger: 'axis', valueFormatter: (v: unknown) => `${Number(v).toLocaleString()} tokens` },
@@ -251,14 +284,14 @@ function renderTokenChart(list: DailyTokenUsageResp[]) {
       type: 'category',
       boundaryGap: false,
       data: list.map(i => i.date.slice(5)),
-      axisLine: { lineStyle: { color: 'rgba(255,255,255,0.25)' } },
-      axisLabel: { color: 'rgba(255,255,255,0.65)' },
+      axisLine: { lineStyle: { color: inkColor(0.25) } },
+      axisLabel: { color: inkColor(0.65) },
     },
     yAxis: {
       type: 'value',
       minInterval: 1,
-      axisLabel: { color: 'rgba(255,255,255,0.65)' },
-      splitLine: { lineStyle: { color: 'rgba(255,255,255,0.1)' } },
+      axisLabel: { color: inkColor(0.65) },
+      splitLine: { lineStyle: { color: inkColor(0.1) } },
     },
     series: [{
       name: 'Token',
@@ -266,9 +299,9 @@ function renderTokenChart(list: DailyTokenUsageResp[]) {
       smooth: true,
       symbolSize: 6,
       data: list.map(i => i.token_count),
-      lineStyle: { width: 2, color: '#6366f1' },
-      itemStyle: { color: '#6366f1' },
-      areaStyle: { color: 'rgba(99,102,241,0.18)' },
+      lineStyle: { width: 2, color: primary },
+      itemStyle: { color: primary },
+      areaStyle: { color: `rgba(${hexToRgb(primary)}, 0.18)` },
     }],
   })
 }
@@ -319,8 +352,8 @@ function renderGauges() {
       endAngle: -30,
       min: 0,
       max,
-      axisLine: { lineStyle: { width: 10, color: [[1, 'rgba(255,255,255,0.08)']] } },
-      progress: { show: true, width: 10, itemStyle: { color: '#fbbf24' } },
+      axisLine: { lineStyle: { width: 10, color: [[1, inkColor(0.08)]] } },
+      progress: { show: true, width: 10, itemStyle: { color: tokenColor('stat-orange') } },
       pointer: { show: false },
       axisTick: { show: false },
       splitLine: { show: false },
@@ -330,7 +363,7 @@ function renderGauges() {
         offsetCenter: [0, '0%'],
         fontSize: 20,
         fontWeight: 700,
-        color: '#e8ecf4',
+        color: tokenColor('on-surface'),
       },
       data: [{ value }],
     }],
@@ -382,7 +415,7 @@ onBeforeUnmount(() => {
 .goroutine-label {
   margin-top: 6px;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.55);
+  color: rgba(var(--v-theme-on-surface), 0.55);
 }
 .progress-item {
   margin-bottom: 22px;
@@ -395,12 +428,12 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   align-items: center;
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(var(--v-theme-on-surface), 0.7);
   margin-bottom: 8px;
 }
 .progress-val {
   font-family: 'Space Mono', 'JetBrains Mono', monospace;
   font-weight: 700;
-  color: #e8ecf4;
+  color: rgb(var(--v-theme-on-surface));
 }
 </style>

--- a/web/src/views/FishCalendarPage.vue
+++ b/web/src/views/FishCalendarPage.vue
@@ -167,28 +167,24 @@ interface CalCell {
 const grid = computed<CalCell[]>(() => {
   const year = viewYear.value
   const month = viewMonth.value
-  const daysInMonth = new Date(year, month, 0).getDate()
-  const firstDay = new Date(year, month - 1, 1).getDay() // 0=周日
-  const leading = (firstDay + 6) % 7 // 周一开头
   const todayStr = new Date().toLocaleDateString('sv') // YYYY-MM-DD
   const cells: CalCell[] = []
-  // 前导空白（上月）
-  const prevDays = new Date(year, month - 1, 0).getDate()
-  for (let i = leading - 1; i >= 0; i--) {
-    const d = prevDays - i
-    const date = fmtDate(new Date(year, month - 2, d))
-    cells.push({ date, day: d, inMonth: false, isToday: date === todayStr, content: affairsMap.value[date] || '' })
-  }
-  for (let d = 1; d <= daysInMonth; d++) {
-    const date = fmtDate(new Date(year, month - 1, d))
-    cells.push({ date, day: d, inMonth: true, isToday: date === todayStr, content: affairsMap.value[date] || '' })
-  }
-  // 补齐到整周
-  while (cells.length % 7 !== 0) {
-    const last = cells[cells.length - 1]
-    const d = Number(last.day) + 1
-    const date = fmtDate(new Date(viewYear.value, viewMonth.value - 1, d))
-    cells.push({ date, day: d, inMonth: false, isToday: false, content: '' })
+  // 从「周一开头的当月 1 号」之前的日期开始，逐日 +1，直到覆盖完整月并补齐到整周。
+  // day 始终取 cursor.getDate()（跨月由 Date 归一化），避免出现 32/33 等非法日期。
+  const first = new Date(year, month - 1, 1)
+  const leading = (first.getDay() + 6) % 7 // 周一开头的前导天数（上月）
+  const afterMonth = new Date(year, month, 1) // 下月 1 号 = 覆盖完整月的边界
+  const cursor = new Date(year, month - 1, 1 - leading)
+  while (cursor < afterMonth || cells.length % 7 !== 0) {
+    const date = fmtDate(cursor)
+    cells.push({
+      date,
+      day: cursor.getDate(),
+      inMonth: cursor.getMonth() === month - 1,
+      isToday: date === todayStr,
+      content: affairsMap.value[date] || '',
+    })
+    cursor.setDate(cursor.getDate() + 1)
   }
   return cells
 })

--- a/web/src/views/LoginPage.vue
+++ b/web/src/views/LoginPage.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="login-page login-ui">
+  <div class="login-page login-ui" :class="{ 'is-light': !themeStore.effectiveDark }">
+    <div class="login-theme-switch">
+      <ThemeModeMenu />
+    </div>
     <div class="login-shell">
       <!-- 左：Logo(左上角) + 原图(居中带框) 2:1 -->
       <section class="banner-panel">
@@ -66,10 +69,13 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToastStore } from '@/stores/toast'
+import { useThemeStore } from '@/stores/theme'
+import ThemeModeMenu from '@/components/shared/ThemeModeMenu.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
 const toastStore = useToastStore()
+const themeStore = useThemeStore()
 
 const username = ref('')
 const password = ref('')
@@ -261,6 +267,49 @@ async function handleLogin() {
 .auth-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 14px 36px rgba(99, 102, 241, 0.5) !important;
+}
+
+/* ============ 主题切换器（右上角） ============ */
+.login-theme-switch {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 5;
+}
+
+/* ============ 浅色变体（is-light 由主题 store 注入） ============ */
+.login-ui.is-light {
+  --ink: #1b2233;
+  --ink-dim: #5d6678;
+  --line: rgba(28, 35, 51, 0.08);
+}
+.login-page.login-ui.is-light {
+  background: #f5f6fa;
+}
+.login-ui.is-light .banner-panel {
+  background: radial-gradient(900px 500px at 20% 10%, rgba(99, 102, 241, 0.08), transparent 60%),
+              radial-gradient(700px 500px at 90% 95%, rgba(139, 92, 246, 0.07), transparent 55%),
+              #f5f6fa;
+}
+.login-ui.is-light .banner-frame {
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12), 0 0 60px rgba(99, 102, 241, 0.08);
+}
+.login-ui.is-light .auth-panel {
+  border-left: 1px solid var(--line);
+  background: linear-gradient(180deg, #ffffff 0%, #f5f6fa 100%);
+}
+.login-ui.is-light .auth-field :deep(.v-field) {
+  background: rgba(28, 35, 51, 0.03) !important;
+}
+.login-ui.is-light .auth-field :deep(.v-field__outline::before) {
+  border-color: rgba(28, 35, 51, 0.14) !important;
+}
+.login-ui.is-light .auth-field :deep(.v-label) {
+  color: rgba(28, 35, 51, 0.55) !important;
+}
+.login-ui.is-light .auth-field :deep(.v-field__prepend-inner .v-icon),
+.login-ui.is-light .auth-field :deep(.v-field__append-inner .v-icon) {
+  color: rgba(28, 35, 51, 0.45) !important;
 }
 
 /* ============ 响应式 ============ */

--- a/web/src/views/LogsPage.vue
+++ b/web/src/views/LogsPage.vue
@@ -246,12 +246,12 @@ onMounted(fetch)
   flex-direction: column;
 }
 
-/* 类 VSCode 只读代码框 */
+/* 类 VSCode 只读代码框（随深浅色主题自动适配） */
 .code-viewer-wrapper {
   border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 6px;
   overflow: hidden;
-  background: #1e1e1e;
+  background: rgb(var(--v-theme-code-bg));
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -265,8 +265,8 @@ onMounted(fetch)
 
 .line-numbers {
   flex: 0 0 48px;
-  background: #1e1e1e;
-  color: #858585;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgba(var(--v-theme-code-fg), 0.55);
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;
@@ -274,7 +274,7 @@ onMounted(fetch)
   padding: 12px 8px 12px 0;
   overflow-y: hidden;
   user-select: none;
-  border-right: 1px solid #2d2d30;
+  border-right: 1px solid rgba(var(--v-theme-code-fg), 0.18);
 }
 
 .line-num {
@@ -285,8 +285,8 @@ onMounted(fetch)
   flex: 1;
   margin: 0;
   padding: 12px 16px;
-  background: #1e1e1e;
-  color: #d4d4d4;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgb(var(--v-theme-code-fg));
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;
@@ -309,7 +309,7 @@ onMounted(fetch)
 }
 .code-area::-webkit-scrollbar-thumb,
 .line-numbers::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(var(--v-theme-code-fg), 0.3);
   border-radius: 4px;
 }
 

--- a/web/src/views/PluginsPage.vue
+++ b/web/src/views/PluginsPage.vue
@@ -147,22 +147,23 @@
               <div v-else-if="configItems.length === 0" class="text-center pa-8 text-medium-emphasis">暂无可配置项</div>
               <div v-else>
                 <div v-for="cfg in configItems" :key="cfg.key" class="mb-4 config-item">
-                  <div class="d-flex align-center justify-space-between">
-                    <div>
+                  <div class="d-flex justify-space-between align-start config-row">
+                    <div class="config-label">
                       <div class="text-body-2 font-weight-bold">{{ cfg.label || cfg.key }}</div>
                       <div v-if="cfg.description" class="text-caption text-medium-emphasis">{{ cfg.description }}</div>
                     </div>
+                    <v-switch
+                      v-if="cfg.type === 'bool'"
+                      class="config-switch"
+                      :model-value="!!configForm[cfg.key]"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      @update:model-value="(v) => setConfigValue(cfg.key, !!v)"
+                    />
                   </div>
-                  <v-switch
-                    v-if="cfg.type === 'bool'"
-                    :model-value="!!configForm[cfg.key]"
-                    color="primary"
-                    density="compact"
-                    hide-details
-                    @update:model-value="(v) => setConfigValue(cfg.key, !!v)"
-                  />
                   <v-text-field
-                    v-else-if="cfg.type === 'string'"
+                    v-if="cfg.type === 'string'"
                     :model-value="configForm[cfg.key]"
                     variant="outlined"
                     density="compact"
@@ -182,7 +183,9 @@
                       />
                       <v-btn icon="mdi-minus" size="small" variant="text" color="error" @click="removeListValue(cfg.key, idx)" />
                     </div>
-                    <v-btn size="small" variant="tonal" color="primary" prepend-icon="mdi-plus" @click="addListValue(cfg.key)">添加一项</v-btn>
+                    <div class="d-flex justify-end">
+                      <v-btn size="small" variant="tonal" color="primary" prepend-icon="mdi-plus" @click="addListValue(cfg.key)">添加一项</v-btn>
+                    </div>
                   </div>
                 </div>
                 <div class="d-flex justify-end mt-4">
@@ -545,5 +548,10 @@ onMounted(fetch)
 .markdown-body :deep(h2:first-child),
 .markdown-body :deep(h3:first-child),
 .markdown-body :deep(p:first-child) { margin-top: 0; }
-.config-item { border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.08); padding-bottom: 12px; }
+/* 右 padding 给开关留出余量：Vuetify 开关在开/关态下小圆点会超出控件盒约 6px，
+   若贴住滚动容器的裁剪边缘会被切掉一半 */
+.config-item { border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.08); padding-bottom: 12px; padding-right: 8px; }
+.config-row { gap: 16px; }
+.config-label { flex: 1 1 auto; min-width: 0; }
+.config-switch { flex-shrink: 0; margin-top: 2px; }
 </style>

--- a/web/src/views/PromptsPage.vue
+++ b/web/src/views/PromptsPage.vue
@@ -455,12 +455,12 @@ onMounted(fetch)
   font-style: italic;
 }
 
-/* 类 VSCode 编辑器 */
+/* 类 VSCode 编辑器（随深浅色主题自动适配） */
 .code-editor-wrapper {
   border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 6px;
   overflow: hidden;
-  background: #1e1e1e;
+  background: rgb(var(--v-theme-code-bg));
 }
 
 .code-editor {
@@ -471,8 +471,8 @@ onMounted(fetch)
 
 .line-numbers {
   flex: 0 0 48px;
-  background: #1e1e1e;
-  color: #858585;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgba(var(--v-theme-code-fg), 0.55);
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;
@@ -480,7 +480,7 @@ onMounted(fetch)
   padding: 12px 8px 12px 0;
   overflow-y: hidden;
   user-select: none;
-  border-right: 1px solid #2d2d30;
+  border-right: 1px solid rgba(var(--v-theme-code-fg), 0.18);
 }
 
 .line-num {
@@ -489,8 +489,8 @@ onMounted(fetch)
 
 .code-textarea {
   flex: 1;
-  background: #1e1e1e;
-  color: #d4d4d4;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgb(var(--v-theme-code-fg));
   border: none;
   outline: none;
   resize: none;
@@ -504,7 +504,7 @@ onMounted(fetch)
 }
 
 .code-textarea::placeholder {
-  color: #6a6a6a;
+  color: rgba(var(--v-theme-code-fg), 0.45);
 }
 
 .code-textarea::-webkit-scrollbar,
@@ -514,7 +514,7 @@ onMounted(fetch)
 }
 .code-textarea::-webkit-scrollbar-thumb,
 .markdown-viewer::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(var(--v-theme-code-fg), 0.3);
   border-radius: 4px;
 }
 </style>

--- a/web/src/views/SessionsPage.vue
+++ b/web/src/views/SessionsPage.vue
@@ -160,7 +160,7 @@ onMounted(fetch)
   border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 6px;
   overflow: hidden;
-  background: #1e1e1e;
+  background: rgb(var(--v-theme-code-bg));
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -174,8 +174,8 @@ onMounted(fetch)
 
 .line-numbers {
   flex: 0 0 48px;
-  background: #1e1e1e;
-  color: #858585;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgba(var(--v-theme-code-fg), 0.55);
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;
@@ -183,7 +183,7 @@ onMounted(fetch)
   padding: 12px 8px 12px 0;
   overflow-y: hidden;
   user-select: none;
-  border-right: 1px solid #2d2d30;
+  border-right: 1px solid rgba(var(--v-theme-code-fg), 0.18);
 }
 
 .line-num {
@@ -194,8 +194,8 @@ onMounted(fetch)
   flex: 1;
   margin: 0;
   padding: 12px 16px;
-  background: #1e1e1e;
-  color: #d4d4d4;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgb(var(--v-theme-code-fg));
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;
@@ -218,7 +218,7 @@ onMounted(fetch)
 }
 .code-area::-webkit-scrollbar-thumb,
 .line-numbers::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(var(--v-theme-code-fg), 0.3);
   border-radius: 4px;
 }
 </style>

--- a/web/src/views/ToolsPage.vue
+++ b/web/src/views/ToolsPage.vue
@@ -115,8 +115,8 @@ onMounted(fetch)
 
 <style scoped>
 .code-block {
-  background: #1e1e1e;
-  color: #d4d4d4;
+  background: rgb(var(--v-theme-code-bg));
+  color: rgb(var(--v-theme-code-fg));
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace;
   font-size: 13px;
   line-height: 1.5;


### PR DESCRIPTION
## 变更内容

1. **深浅色主题切换**：顶栏「刷新数据」与头像之间、登录页右上角新增 MD3 主题下拉菜单，支持 跟随系统 / 深色 / 浅色，选择持久化到 localStorage，并监听系统偏好实时响应。
2. **统一双主题 token**（`theme.ts`）：浅色模式侧边栏切换为白色、代码区按主题配色（`code-*` 语法 token）；Dashboard 进度条/ECharts 改为主题感知。
3. **代码区收敛**：Logs/CronJob/Prompt/Session/Tool 的代码框与 CodeMirror 行号全部收敛到主题 token，随深浅切换自动适配。
4. **插件配置页布局修复**：布尔开关与标签同排右对齐、修复开关小圆点被滚动容器裁剪、「添加一项」按钮右对齐。
5. **摸鱼人日历日期修复**：月尾补齐整周时 `day` 手动累加导致 31 号后出现 32/33 等非法日期，改为 Date 逐日迭代取 `getDate()`，覆盖 31/30/28 天月、跨年与平闰二月。

## 影响范围

- [ ] 后端（Go）
- [x] 前端（web/）
- [ ] 文档
- [ ] 配置/部署
- [ ] 其他

## 验证

- `vue-tsc --noEmit` 通过；`npm run build` 成功
- mock 环境深浅两模式截图经 claude-vision 逐张视觉确认（侧边栏/日志弹窗/CronJob Payload/Prompt 编辑器/Tool Schema）
- 摸鱼人日历 mock 遍历 2026-08 ~ 2027-03 共 8 个月份程序化断言 + 2026-08/09 视觉确认，无 >31 非法日期
- 已部署本地容器 `juanniang-neo-local` 实测通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增主题模式切换，可选择跟随系统、深色或浅色模式。
  - 登录页和应用头部均支持快速切换主题，主题选择会自动保存并恢复。
- **改进**
  - 仪表盘、代码编辑器、日志及会话查看器等界面自动适配当前主题。
  - 优化侧边栏、插件配置项及页面背景的明暗主题显示效果。
- **Bug 修复**
  - 优化日历网格生成，确保月份日期、周起始日及跨月日期显示正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->