### PR TITLE
docs: clarify jn.file path base in plugin-development.md

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -213,22 +213,26 @@ log.error("操作失败: " .. err)
 | `file.exists(path) → bool` | bool | 判断文件是否存在 |
 | `file.remove(path) → bool [, err]` | bool | 删除文件 |
 
+> **路径基准**：`jn.file` 的所有 `path` 均**相对于插件自身目录** `data/pluggins/<插件名>/`，
+> 而非仓库根目录。写 `notes.txt` 实际写入 `data/pluggins/<插件名>/notes.txt`。
+> 禁止绝对路径与 `..` 越界，插件之间彼此隔离。
+
 ```lua
 -- 逐行读取（read_line 越界返回 nil，可用作循环终止条件）
 local i = 1
 while true do
-    local line = jn.file.read_line("data/notes.txt", i)
+    local line = jn.file.read_line("notes.txt", i)
     if line == nil then break end
     log.info(line)
     i = i + 1
 end
 
 -- 整体读写
-jn.file.write("data/state.txt", "hello")
-local content = jn.file.read("data/state.txt")
+jn.file.write("state.txt", "hello")
+local content = jn.file.read("state.txt")
 
 -- 追加一行
-jn.file.append_line("data/log.txt", "事件发生于 " .. os.date())
+jn.file.append_line("log.txt", "事件发生于 " .. os.date())
 ```
 
 ## 全局表: `onebot11`


### PR DESCRIPTION
修复 `docs/plugin-development.md` 中 `jn.file` 示例路径与实际插件目录不一致的问题。

## 依据

路径基准在代码中是明确的 —— `internal/pluggin/file.go`：

```go
// 所有路径均相对于插件自身目录 (data/pluggins/<name>/)，仅可读写文本文件。
func pluginFilePath(basePath, pluginName, path string) (string, error) {
	if path == "" || filepath.IsAbs(path) {
		return "", errInvalidPluginPath
	}
	pluginDir := filepath.Join(basePath, pluginName)
	full := filepath.Join(pluginDir, path)
	...
}
```

所以原示例里的 `"data/notes.txt"` 实际解析为 `data/pluggins/<插件名>/data/notes.txt` —— 插件目录**内**多出一层 `data/`，而不是新生按字面理解的仓库根 `data/`。这个巧合正是文档最容易误导人的地方。

## 改动

1. 示例路径去掉 `data/` 前缀：`data/notes.txt` → `notes.txt`，`state.txt`、`log.txt` 同理（第 220、227、228、231 行）。
2. 在示例前补一段**路径基准**说明，明确三点：相对于 `data/pluggins/<插件名>/` 而非仓库根、给出实际解析结果、禁止绝对路径与 `..` 越界。

第 110 行表格里"插件目录内文本文件读写"的措辞本身没错，只是示例与它矛盾，所以只改示例并补充说明，未改表格。

仅改动 `docs/`，无代码风险。

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新 `jn.file` 路径说明，明确路径相对于插件自身目录。
  * 补充限制：禁止使用绝对路径或通过 `..` 越过插件目录。
  * 修正示例中的路径格式，移除多余的 `data/` 前缀。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->