### PR TITLE
docs: document env to devconfig.go field mapping

### DIFF
--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -15,6 +15,31 @@
 
 所有持久化在 Postgres + Redis（短期记忆窗口、PubSub、任意缓存）。`.env` 中的 `T2I_BASE_URL`/`SANDBOX_*` 仅是文档性 env，**运行时实际从 DB 读取**。
 
+### env 变量与 `devconfig.go` 字段的对应
+
+上表「配置来源」写的 `DB_*` / `REDIS_*` 是 **env 变量名**，与 `cmd/server/devconfig.go` 里的嵌套 struct 字段并不同名，两者由 `cmd/server/main.go` 显式配对。
+
+优先级由 `devEnv(envKey, yamlVal, fallback)` 决定（`cmd/server/devconfig.go:59`）：**env 变量 > `dev.yaml` > 内置默认值**，空字符串视为未设置、继续向后取。
+
+| env 变量 | `dev.yaml` 路径 | `DevConfig` 字段 | 默认值 |
+|----------|-----------------|------------------|--------|
+| `DB_HOST` | `database.host` | `Database.Host` | `localhost` |
+| `DB_PORT` | `database.port` | `Database.Port` | `5432` |
+| `DB_USER` | `database.user` | `Database.User` | `postgres` |
+| `DB_PASSWORD` | `database.password` | `Database.Password` | `postgres` |
+| `DB_NAME` | `database.name` | `Database.Name` | `juan` |
+| `REDIS_ADDR` | `redis.addr` | `Redis.Addr` | `localhost:6379` |
+| `REDIS_PASSWORD` | `redis.password` | `Redis.Password` | `root` |
+| `REDIS_DB` | `redis.db` | `Redis.DB` | `0` |
+| `JWT_SECRET` | `jwt.secret` | `JWT.Secret` | 无（留空则不启用） |
+| `IMG_DIR` | `images.dir` | `Images.Dir` | `data/imgs` |
+| `WEB_DIR` | `web.dir` | `Web.Dir` | `web/dist` |
+| `API_ADDR` | `api.addr` | `API.Addr` | `:8090` |
+
+注意 Redis 用的是 `REDIS_ADDR`（`host:port` 合并写法），**没有** `REDIS_HOST` / `REDIS_PORT`；Postgres 则是 host 与 port 分开。
+
+`REDIS_PREFIX` 不走这套映射，由 `internal/core/core.go` 直接 `os.Getenv` 读取，`dev.yaml` 中无对应项。
+
 ## LLM Provider
 
 ### 设计


### PR DESCRIPTION
在 `docs/external-services.md` 总览表后补一节，说明 env 变量与 `cmd/server/devconfig.go` struct 字段的对应关系。

## 为什么是「对应」而不是「同名」

`devconfig.go` 的 struct 只有 `yaml:` tag，没有 env tag —— 两者不是自动绑定的，而是在 `cmd/server/main.go` 里由 `devEnv(envKey, yamlVal, fallback)` 一处处显式配对。这正是新生查不到的原因：在 `devconfig.go` 里搜 `REDIS_` 一个字都找不到。

优先级也一并写清楚了（`devconfig.go:59`）：**env > `dev.yaml` > 内置默认值**，空字符串视为未设置继续向后取。

## 表格内容

12 行，逐条从 `main.go` 的 `devEnv` 调用抄出来，不是凭印象写的。我用脚本把文档里每一行的 env 名、struct 字段、默认值都对着 `main.go` 校验了一遍，12/12 一致。

顺带写进去两个容易踩的点：

- Redis 用的是 `REDIS_ADDR`（`host:port` 合并），**没有** `REDIS_HOST` / `REDIS_PORT` —— 这恰好是 issue 里举例要找的两个变量。已确认 `main.go` 中零处出现。Postgres 反而是 host / port 分开的，两者不一致，容易先入为主。
- `REDIS_PREFIX` 不走这套映射，是 `internal/core/core.go` 直接 `os.Getenv` 读的，`dev.yaml` 里没有对应项。

## 未改动的部分

issue 提到 `docs/deployment.md` 第 42-52 行也描述了 `dev.yaml` 却没说映射关系。我没有在那边复制一份表格 —— 同一份内容两处维护迟早会分叉，这正是本 issue 描述的那类问题。如果你希望 `deployment.md` 也能就近看到，我可以补一个指向本节的链接。

仅改动 `docs/`，无代码风险。

Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增环境变量与开发配置字段的对应关系说明。
  * 补充配置优先级、数据库、Redis、JWT、目录及 API 等配置项的映射与默认值。
  * 明确 Redis 地址及前缀相关配置的使用方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->